### PR TITLE
test(fe): drive the session scenarios in a browser

### DIFF
--- a/.github/versions/test-app
+++ b/.github/versions/test-app
@@ -1,1 +1,1 @@
-release-2026-08-03
+prerelease-2026-08-26-sessions-2

--- a/src/frontend/tests/e2e-playwright/fixtures/authorize.ts
+++ b/src/frontend/tests/e2e-playwright/fixtures/authorize.ts
@@ -1,5 +1,6 @@
 import { IDL } from "@icp-sdk/core/candid";
 import { Principal } from "@icp-sdk/core/principal";
+import { readCanisterId } from "@dfinity/internet-identity-vite-plugins/utils";
 import { test as base, expect, type Page } from "@playwright/test";
 import { II_URL, toBase64 } from "../utils";
 
@@ -43,6 +44,34 @@ class AuthorizePage {
     return this.#page;
   }
 }
+
+/**
+ * Waits for a sign-in to have produced its result on the test app's page.
+ *
+ * The provider's window closes before the app has anything to show: over the
+ * session protocol the app has still to mint a delegation, and the redirect
+ * transport has still to navigate back. The app hides `#principal` until it has
+ * one, so its appearance is the signal that the rest of the page can be read.
+ *
+ * A sign-in that produced nothing never shows it, and so does a test that drove
+ * the provider directly and has no test app page at all. Both are outcomes the
+ * readers below report rather than fail on, so the wait is bounded and running
+ * out is not an error.
+ */
+const waitForSignInResult = async (
+  testAppPage: Page,
+  authPage: Page | undefined,
+): Promise<void> => {
+  if (authPage !== undefined) {
+    await authPage.waitForEvent("close", { timeout: 15_000 });
+  }
+  if ((await testAppPage.locator("#principal").count()) === 0) {
+    return;
+  }
+  await expect(testAppPage.locator("#principal"))
+    .toBeVisible({ timeout: 15_000 })
+    .catch(() => undefined);
+};
 
 export const test = base.extend<{
   authorizeConfig: Partial<AuthorizeConfig> | undefined;
@@ -113,8 +142,13 @@ export const test = base.extend<{
         .getByRole("textbox", { name: "Identity Provider" })
         .fill(internetIdentityURL + "/authorize" + querySuffix);
       await testAppPage
-        .getByRole("checkbox", { name: "Use ICRC-25 protocol:" })
+        .getByRole("checkbox", { name: "Use ICRC-25 and sessions:" })
         .setChecked(true);
+      // The client refuses a session chain that names any provider but the one it
+      // was configured with, and its default is the mainnet canister.
+      await testAppPage
+        .getByRole("textbox", { name: "II canister id:" })
+        .fill(readCanisterId({ canisterName: "internet_identity" }));
       if (
         "useIcrc3Attributes" in authorizeConfig &&
         authorizeConfig.useIcrc3Attributes === true
@@ -186,18 +220,9 @@ export const test = base.extend<{
       }
     }
   },
-  authorizedPrincipal: async ({ page, authorizeConfig }, use) => {
+  authorizedPrincipal: async ({ page }, use) => {
     const [testAppPage, authPage] = page.context().pages();
-    if (authPage !== undefined) {
-      await authPage.waitForEvent("close", { timeout: 15_000 });
-    }
-    // The redirect flow renders the principal only after navigating back to the
-    // test app, so wait for it before reading (window flow already has it).
-    if (authorizeConfig?.transport === "redirect") {
-      await expect(testAppPage.locator("#principal")).toBeVisible({
-        timeout: 15_000,
-      });
-    }
+    await waitForSignInResult(testAppPage, authPage);
 
     const principal = await testAppPage.locator("#principal").textContent();
     if (principal === null) {
@@ -208,9 +233,7 @@ export const test = base.extend<{
   },
   authorizedAttributes: async ({ page }, use) => {
     const [testAppPage, authPage] = page.context().pages();
-    if (authPage !== undefined) {
-      await authPage.waitForEvent("close", { timeout: 15_000 });
-    }
+    await waitForSignInResult(testAppPage, authPage);
 
     const attributes = await testAppPage
       .locator("#certifiedAttributes")
@@ -228,18 +251,9 @@ export const test = base.extend<{
       ),
     );
   },
-  authorizedIcrc3Attributes: async ({ page, authorizeConfig }, use) => {
+  authorizedIcrc3Attributes: async ({ page }, use) => {
     const [testAppPage, authPage] = page.context().pages();
-    if (authPage !== undefined) {
-      await authPage.waitForEvent("close", { timeout: 15_000 });
-    }
-    // The redirect flow renders results only after navigating back to the test
-    // app, so wait for the return (principal visible) before reading.
-    if (authorizeConfig?.transport === "redirect") {
-      await expect(testAppPage.locator("#principal")).toBeVisible({
-        timeout: 15_000,
-      });
-    }
+    await waitForSignInResult(testAppPage, authPage);
 
     // Tests that bypass the test_app entirely (e.g. the channel-error
     // test that goes straight to the authorize URL) won't have the
@@ -258,18 +272,9 @@ export const test = base.extend<{
 
     await use(JSON.parse(icrc3Attributes));
   },
-  authorizedDelegation: async ({ page, authorizeConfig }, use) => {
+  authorizedDelegation: async ({ page }, use) => {
     const [testAppPage, authPage] = page.context().pages();
-    if (authPage !== undefined) {
-      await authPage.waitForEvent("close", { timeout: 15_000 });
-    }
-    // The redirect flow renders the delegation only after navigating back to
-    // the test app, so wait for the return (principal visible) before reading.
-    if (authorizeConfig?.transport === "redirect") {
-      await expect(testAppPage.locator("#principal")).toBeVisible({
-        timeout: 15_000,
-      });
-    }
+    await waitForSignInResult(testAppPage, authPage);
 
     const delegation = await testAppPage.locator("#delegation").innerText();
     // The test app writes a plain status string here (e.g. "Current identity is

--- a/src/frontend/tests/e2e-playwright/fixtures/index.ts
+++ b/src/frontend/tests/e2e-playwright/fixtures/index.ts
@@ -13,6 +13,7 @@ import { test as emailRecoveryTest } from "./emailRecovery";
 import { test as verifiedEmailTest } from "./verifiedEmail";
 import { test as cliTest } from "./cli";
 import { test as mcpTest } from "./mcp";
+import { test as testAppTest } from "./testApp";
 
 export const test = mergeTests(
   inertWorkaroundTest,
@@ -29,4 +30,5 @@ export const test = mergeTests(
   verifiedEmailTest,
   cliTest,
   mcpTest,
+  testAppTest,
 );

--- a/src/frontend/tests/e2e-playwright/fixtures/testApp.ts
+++ b/src/frontend/tests/e2e-playwright/fixtures/testApp.ts
@@ -1,0 +1,243 @@
+import {
+  expect,
+  test as base,
+  type Locator,
+  type Page,
+} from "@playwright/test";
+import { readCanisterId } from "@dfinity/internet-identity-vite-plugins/utils";
+import { II_URL, TEST_APP_URL } from "../utils";
+
+/**
+ * The test app, addressed by what it does rather than by which element does it.
+ *
+ * The session panel is the reason this exists: a scenario about sessions is
+ * mostly assertions on what the panel says, and spelling those as `#sessionState`
+ * in every test buries the scenario in selectors.
+ */
+
+const II_CANISTER_ID = readCanisterId({ canisterName: "internet_identity" });
+
+export interface TestAppOptions {
+  /** Defaults to `TEST_APP_URL`. */
+  url?: string;
+  /** The identity provider's authorize URL. Defaults to the local II. */
+  authorizeUrl?: string;
+  /**
+   * Which protocol the sign-in button uses. `"session"` is `AuthClient` and
+   * creates a session; `"legacy"` is the raw postMessage flow and creates none.
+   * Always stated, so the app's own default never decides what a test exercises.
+   */
+  protocol?: "session" | "legacy";
+  derivationOrigin?: string;
+  /** Announces the session across the siblings of this domain. */
+  cookieDomain?: string;
+}
+
+export class TestApp {
+  readonly page: Page;
+
+  constructor(page: Page) {
+    this.page = page;
+  }
+
+  /** What the panel reports. */
+  get state(): Locator {
+    return this.page.locator("#sessionState");
+  }
+  /** The principal an app's canisters see. */
+  get account(): Locator {
+    return this.page.locator("#sessionAccountPrincipal");
+  }
+  /** The key II resolves the session from. */
+  get sessionKey(): Locator {
+    return this.page.locator("#sessionSessionPrincipal");
+  }
+  get sessionExpiry(): Locator {
+    return this.page.locator("#sessionExpiry");
+  }
+  get delegation(): Locator {
+    return this.page.locator("#delegationExpiry");
+  }
+  get replacements(): Locator {
+    return this.page.locator("#delegationChanges");
+  }
+  /** What the siblings of a domain share. */
+  get sharedHint(): Locator {
+    return this.page.locator("#sessionHint");
+  }
+  get log(): Locator {
+    return this.page.locator("#sessionLog");
+  }
+  get principal(): Locator {
+    return this.page.locator("#principal");
+  }
+
+  /** Opens the app and states which provider and protocol to use. */
+  async open(options: TestAppOptions = {}): Promise<void> {
+    await this.page.goto(options.url ?? TEST_APP_URL);
+    await this.page
+      .getByRole("textbox", { name: "Identity Provider" })
+      .fill(options.authorizeUrl ?? `${II_URL}/authorize`);
+    await this.page
+      .getByRole("checkbox", { name: "Use ICRC-25 and sessions:" })
+      .setChecked((options.protocol ?? "session") === "session");
+    if ((options.protocol ?? "session") === "session") {
+      // The client refuses a session chain naming any provider but the one it was
+      // configured with, and its default is the mainnet canister.
+      await this.page
+        .getByRole("textbox", { name: "II canister id:" })
+        .fill(II_CANISTER_ID);
+    }
+    if (options.derivationOrigin !== undefined) {
+      await this.page
+        .locator("#derivationOrigin")
+        .fill(options.derivationOrigin);
+    }
+    if (options.cookieDomain !== undefined) {
+      await this.page.locator("#sessionStorageCookie").check();
+      await this.page
+        .locator("#sessionCookieDomain")
+        .fill(options.cookieDomain);
+      await this.page.locator("#sessionCookieDomain").blur();
+    }
+  }
+
+  /** How many windows the browser holding this app has open. */
+  get openWindows(): number {
+    return this.page.context().pages().length;
+  }
+
+  /** Closes this tab. */
+  async close(): Promise<void> {
+    await this.page.close();
+  }
+
+  /** Arrives at the app without filling anything in, as a second tab does. */
+  async visit(url: string = TEST_APP_URL): Promise<void> {
+    await this.page.goto(url);
+  }
+
+  /** Loads the app again in the same tab. */
+  async reload(): Promise<void> {
+    await this.page.reload();
+  }
+
+  /** Brings this tab forward without announcing it, which a click would. */
+  async focus(): Promise<void> {
+    await this.page.bringToFront();
+  }
+
+  /**
+   * Runs a sign-in and waits for the app to actually hold a session.
+   *
+   * The provider's window closes when it is done, which is before the app has
+   * minted and stored anything, so waiting on the window alone races the result.
+   */
+  async signIn(authenticate: (authPage: Page) => Promise<void>): Promise<void> {
+    const authPagePromise = this.page.context().waitForEvent("page");
+    await this.page.getByRole("button", { name: "Sign In" }).click();
+    const authPage = await authPagePromise;
+    await authenticate(authPage);
+    await authPage.waitForEvent("close", { timeout: 15_000 });
+    await expect(this.state).toHaveText("signed in", { timeout: 20_000 });
+  }
+
+  /** Signs in and abandons the ceremony part way through. */
+  async abandonSignIn(part: (authPage: Page) => Promise<void>): Promise<void> {
+    const authPagePromise = this.page.context().waitForEvent("page");
+    await this.page.getByRole("button", { name: "Sign In" }).click();
+    const authPage = await authPagePromise;
+    await part(authPage);
+    await authPage.close();
+  }
+
+  async signOut(): Promise<void> {
+    await this.page.getByRole("button", { name: "Sign out" }).first().click();
+  }
+
+  /** Asks for a replacement now rather than waiting for one to be due. */
+  async replaceDelegation(): Promise<void> {
+    await this.page.getByRole("button", { name: "Refresh now" }).click();
+  }
+
+  /** Asks the provider to re-issue without rendering anything. */
+  async silentReauth(): Promise<void> {
+    await this.page.getByRole("button", { name: "Silent re-auth" }).click();
+  }
+
+  /** Makes a real canister call as whoever the app is acting as. */
+  async whoAmI(): Promise<void> {
+    await this.page.getByRole("button", { name: "Who am I?" }).click();
+    await expect(this.page.locator("#whoamiResponse")).not.toHaveText(
+      "Loading...",
+      { timeout: 30_000 },
+    );
+  }
+
+  /** Brings this tab forward, which is a trigger for replacing a delegation. */
+  async returnToTab(): Promise<void> {
+    await this.page.bringToFront();
+    await this.page.evaluate(() =>
+      document.dispatchEvent(new Event("visibilitychange")),
+    );
+  }
+
+  /** Moves this page past the point where its delegation is due. */
+  async ageDelegation(duration = "05:30"): Promise<void> {
+    await this.page.clock.install();
+    await this.page.clock.fastForward(duration);
+  }
+
+  /** Forgets everything this origin stored, as clearing site data would. */
+  async clearSiteData(): Promise<void> {
+    await this.page.evaluate(async () => {
+      localStorage.clear();
+      const databases = (await indexedDB.databases?.()) ?? [];
+      await Promise.all(
+        databases.map(
+          ({ name }) =>
+            new Promise((resolve) => {
+              if (name === undefined) return resolve(undefined);
+              const request = indexedDB.deleteDatabase(name);
+              request.onsuccess =
+                request.onerror =
+                request.onblocked =
+                  () => resolve(undefined);
+            }),
+        ),
+      );
+    });
+  }
+
+  /**
+   * Lists origins as alternatives of the derivation origin they share.
+   *
+   * One canister serves every host the dev server maps here, so this is written
+   * once and every one of them reads the same list.
+   */
+  async declareAlternativeOrigins(origins: string[]): Promise<void> {
+    const alternativeOrigins = JSON.stringify({ alternativeOrigins: origins });
+    await this.page.locator("#hostUrl").fill("https://localhost:5173");
+    await this.page.locator("#newAlternativeOrigins").fill(alternativeOrigins);
+    await this.page.locator("#certified").click();
+    await this.page.locator("#updateNewAlternativeOrigins").click();
+    await expect(this.page.locator("#alternativeOrigins")).toHaveText(
+      alternativeOrigins,
+      { timeout: 15_000 },
+    );
+  }
+}
+
+export const test = base.extend<{
+  testApp: TestApp;
+  /** The same app in another tab, window or browser. */
+  openTestApp: (page: Page) => TestApp;
+}>({
+  testApp: async ({ page }, use) => {
+    await use(new TestApp(page));
+  },
+  // eslint-disable-next-line no-empty-pattern
+  openTestApp: async ({}, use) => {
+    await use((page: Page) => new TestApp(page));
+  },
+});

--- a/src/frontend/tests/e2e-playwright/fixtures/testApp.ts
+++ b/src/frontend/tests/e2e-playwright/fixtures/testApp.ts
@@ -112,6 +112,16 @@ export class TestApp {
     await this.page.close();
   }
 
+  /**
+   * Waits until the app holds a session.
+   *
+   * `afterEach` runs before the sign-in fixture's own teardown, so the
+   * provider's window may still be closing and the app may still be minting.
+   */
+  async waitUntilSignedIn(): Promise<void> {
+    await expect(this.state).toHaveText("signed in", { timeout: 20_000 });
+  }
+
   /** Arrives at the app without filling anything in, as a second tab does. */
   async visit(url: string = TEST_APP_URL): Promise<void> {
     await this.page.goto(url);

--- a/src/frontend/tests/e2e-playwright/fixtures/testApp.ts
+++ b/src/frontend/tests/e2e-playwright/fixtures/testApp.ts
@@ -112,12 +112,7 @@ export class TestApp {
     await this.page.close();
   }
 
-  /**
-   * Waits until the app holds a session.
-   *
-   * `afterEach` runs before the sign-in fixture's own teardown, so the
-   * provider's window may still be closing and the app may still be minting.
-   */
+  /** Waits until the app holds a session. */
   async waitUntilSignedIn(): Promise<void> {
     await expect(this.state).toHaveText("signed in", { timeout: 20_000 });
   }
@@ -240,11 +235,29 @@ export class TestApp {
 
 export const test = base.extend<{
   testApp: TestApp;
+  /**
+   * The app once it holds a session, for a hook that reads what a sign-in left
+   * behind.
+   *
+   * `afterEach` runs before the sign-in fixture's own teardown, so the
+   * provider's window may still be closing and the app may still be minting.
+   * Waiting here rather than in each hook keeps that out of the scenarios, the
+   * way `authorizedPrincipal` does for the specs that read a principal.
+   *
+   * Only a hook should ask for this. A test body that asks for it waits for a
+   * sign-in that has not been started yet.
+   */
+  signedInApp: TestApp;
   /** The same app in another tab, window or browser. */
   openTestApp: (page: Page) => TestApp;
 }>({
   testApp: async ({ page }, use) => {
     await use(new TestApp(page));
+  },
+  signedInApp: async ({ page }, use) => {
+    const app = new TestApp(page);
+    await app.waitUntilSignedIn();
+    await use(app);
   },
   // eslint-disable-next-line no-empty-pattern
   openTestApp: async ({}, use) => {

--- a/src/frontend/tests/e2e-playwright/routes/authorize/alternativeOrigins.spec.ts
+++ b/src/frontend/tests/e2e-playwright/routes/authorize/alternativeOrigins.spec.ts
@@ -5,6 +5,7 @@ import {
   NOT_TEST_APP_URL,
   TEST_APP_CANONICAL_URL,
   TEST_APP_URL,
+  useLegacyProtocol,
 } from "../../utils";
 import { test } from "../../fixtures";
 
@@ -12,6 +13,7 @@ test("Should not issue delegation when alternative origins are empty", async ({
   page,
 }) => {
   await page.goto(TEST_APP_URL);
+  await useLegacyProtocol(page);
 
   // Configure the test app
   await page.getByRole("textbox", { name: "Identity Provider" }).fill(II_URL);
@@ -44,6 +46,7 @@ test("Should not issue delegation when origin is missing from /.well-known/ii-al
   page,
 }) => {
   await page.goto(TEST_APP_URL);
+  await useLegacyProtocol(page);
 
   // Configure the test app
   await page.getByRole("textbox", { name: "Identity Provider" }).fill(II_URL);
@@ -78,6 +81,7 @@ test("Should issue delegation when derivationOrigin is properly configured in /.
   page,
 }) => {
   await page.goto(TEST_APP_URL);
+  await useLegacyProtocol(page);
 
   // Configure the test app
   await page.getByRole("textbox", { name: "Identity Provider" }).fill(II_URL);
@@ -126,6 +130,7 @@ test("Should not issue delegation when /.well-known/ii-alternative-origins has t
   page,
 }) => {
   await page.goto(TEST_APP_URL);
+  await useLegacyProtocol(page);
 
   // Configure the test app
   await page.getByRole("textbox", { name: "Identity Provider" }).fill(II_URL);
@@ -166,6 +171,7 @@ test("Should not follow redirect returned by /.well-known/ii-alternative-origins
   page,
 }) => {
   await page.goto(TEST_APP_URL);
+  await useLegacyProtocol(page);
 
   // Configure the test app
   await page.getByRole("textbox", { name: "Identity Provider" }).fill(II_URL);
@@ -208,6 +214,7 @@ test("Should issue the same principal to nice url and canonical url", async ({
 }) => {
   // First authentication: Test app configured with canonical URL as derivation origin
   await page.goto(TEST_APP_URL);
+  await useLegacyProtocol(page);
   await page.getByRole("textbox", { name: "Identity Provider" }).fill(II_URL);
   await page.locator("#hostUrl").fill("https://localhost:5173");
 
@@ -251,6 +258,7 @@ test("Should issue the same principal to nice url and canonical url", async ({
   // Clear the current session by reloading the page
   await page.reload();
   await page.goto(TEST_APP_CANONICAL_URL);
+  await useLegacyProtocol(page);
   await page.getByRole("textbox", { name: "Identity Provider" }).fill(II_URL);
   await page.locator("#hostUrl").fill("https://localhost:5173");
 

--- a/src/frontend/tests/e2e-playwright/routes/authorize/app-sessions.spec.ts
+++ b/src/frontend/tests/e2e-playwright/routes/authorize/app-sessions.spec.ts
@@ -1,0 +1,657 @@
+import { expect, type Page } from "@playwright/test";
+import { test } from "../../fixtures";
+import {
+  II_URL,
+  TEST_APP_CANONICAL_URL,
+  TEST_APP_DERIVATION_ORIGIN,
+  TEST_APP_SIBLING_A_URL,
+  TEST_APP_SIBLING_B_URL,
+} from "../../utils";
+
+/**
+ * The scenarios from `docs/ongoing/session-test-scenarios.md` that a browser can
+ * reach. The test app's session panel is what makes them observable: it reports
+ * the account the app acts as, what the session and the app delegation have left,
+ * and a log of what the library did.
+ */
+
+/** The commonest sign-in: pick an identity, then continue. */
+const continueAs =
+  (
+    identityNumber: bigint,
+    signInWithIdentity: (page: Page, identityNumber: bigint) => Promise<void>,
+  ) =>
+  async (authPage: Page): Promise<void> => {
+    await signInWithIdentity(authPage, identityNumber);
+    await authPage
+      .getByRole("button", { name: "Continue", exact: true })
+      .click();
+  };
+
+/** The identity's settings, signed in, with the browser list on screen. */
+const openSettings = async (
+  context: { newPage: () => Promise<Page> },
+  identityNumber: bigint,
+  signInWithIdentity: (page: Page, identityNumber: bigint) => Promise<void>,
+): Promise<Page> => {
+  const settings = await context.newPage();
+  await settings.goto(`${II_URL}/manage/settings`);
+  await signInWithIdentity(settings, identityNumber);
+  await expect(
+    settings.getByRole("heading", { name: "Signed-in browsers" }),
+  ).toBeVisible();
+  return settings;
+};
+
+const SHARED_DOMAIN = "nice-name.com";
+
+test.describe("app sessions", () => {
+  test("FIRST-1: a first sign-in leaves the app holding a session and a delegation", async ({
+    testApp,
+    identities,
+    signInWithIdentity,
+  }) => {
+    await testApp.open();
+    await testApp.signIn(
+      continueAs(identities[0].identityNumber, signInWithIdentity),
+    );
+
+    await expect(testApp.account).not.toHaveText("-");
+    // The ceremony mints before it resolves, so a delegation is held straight
+    // away rather than only once the tab next comes forward.
+    await expect(testApp.delegation).not.toHaveText("none held");
+  });
+
+  test("one identity is a different account at each app", async ({
+    testApp,
+    openTestApp,
+    context,
+    identities,
+    signInWithIdentity,
+  }) => {
+    const authenticate = continueAs(
+      identities[0].identityNumber,
+      signInWithIdentity,
+    );
+
+    await testApp.open();
+    await testApp.signIn(authenticate);
+    const here = await testApp.account.textContent();
+
+    // The same app on another origin. `NOT_TEST_APP_URL` is not the app at all:
+    // every unknown host resolves to the II dev server.
+    const elsewhere = openTestApp(await context.newPage());
+    await elsewhere.open({ url: TEST_APP_CANONICAL_URL });
+    await elsewhere.signIn(authenticate);
+
+    await expect(elsewhere.account).not.toHaveText(here ?? "");
+    await elsewhere.close();
+  });
+
+  test("FIRST-3: signing in twice from one browser replaces the session rather than adding one", async ({
+    testApp,
+    identities,
+    signInWithIdentity,
+  }) => {
+    const authenticate = continueAs(
+      identities[0].identityNumber,
+      signInWithIdentity,
+    );
+    await testApp.open();
+    await testApp.signIn(authenticate);
+    const before = await testApp.sessionKey.textContent();
+
+    await testApp.signIn(authenticate);
+
+    await expect(testApp.sessionKey).not.toHaveText(before ?? "");
+  });
+
+  test("HOLD-1: the app keeps working for longer than one app delegation lasts", async ({
+    testApp,
+    identities,
+    signInWithIdentity,
+  }) => {
+    await testApp.open();
+    await testApp.signIn(
+      continueAs(identities[0].identityNumber, signInWithIdentity),
+    );
+    await expect(testApp.account).not.toHaveText("-");
+    const account = await testApp.account.textContent();
+
+    await testApp.ageDelegation();
+    await testApp.replaceDelegation();
+
+    await expect(testApp.state).toHaveText("signed in");
+    await expect(testApp.delegation).not.toHaveText("none held");
+    await expect(testApp.account).toHaveText(account ?? "");
+    await expect(testApp.replacements).not.toHaveText("0");
+  });
+
+  test("HOLD-2: an app left open and untouched replaces nothing", async ({
+    testApp,
+    identities,
+    signInWithIdentity,
+  }) => {
+    await testApp.open();
+    await testApp.signIn(
+      continueAs(identities[0].identityNumber, signInWithIdentity),
+    );
+    await expect(testApp.replacements).toHaveText("0");
+
+    // MINT-5 and MINT-14: the scheduled refresh cancels unless the delegation it
+    // would replace signed a request, so an idle tab spends nothing.
+    await testApp.ageDelegation();
+    await testApp.page.waitForTimeout(1000);
+
+    await expect(testApp.replacements).toHaveText("0");
+  });
+
+  test("HOLD-3: coming back to a tab replaces the delegation without being asked", async ({
+    testApp,
+    identities,
+    signInWithIdentity,
+  }) => {
+    await testApp.open();
+    await testApp.signIn(
+      continueAs(identities[0].identityNumber, signInWithIdentity),
+    );
+    await expect(testApp.replacements).toHaveText("0");
+
+    // A delegation earns a replacement only once something used it (MINT-5).
+    await testApp.whoAmI();
+
+    // MINT-7: the tab coming forward is the trigger; nothing is clicked to mint.
+    await testApp.ageDelegation("04:55");
+    await testApp.returnToTab();
+
+    await expect(testApp.replacements).not.toHaveText("0", { timeout: 30_000 });
+    await expect(testApp.state).toHaveText("signed in");
+  });
+
+  test("HOLD-4: replacing the delegation renders nothing and keeps the account", async ({
+    testApp,
+    identities,
+    signInWithIdentity,
+  }) => {
+    await testApp.open();
+    await testApp.signIn(
+      continueAs(identities[0].identityNumber, signInWithIdentity),
+    );
+    await expect(testApp.account).not.toHaveText("-");
+    const account = await testApp.account.textContent();
+    const windowsBefore = testApp.openWindows;
+
+    await testApp.replaceDelegation();
+
+    // MINT-16: the account does not move. USE-6: nothing is rendered to do it.
+    await expect(testApp.account).toHaveText(account ?? "");
+    await expect(testApp.delegation).not.toHaveText("none held");
+    expect(testApp.openWindows).toBe(windowsBefore);
+  });
+
+  test("HOLD-6: a reload comes back signed in, asking for nothing", async ({
+    testApp,
+    identities,
+    signInWithIdentity,
+  }) => {
+    await testApp.open();
+    await testApp.signIn(
+      continueAs(identities[0].identityNumber, signInWithIdentity),
+    );
+    await expect(testApp.account).not.toHaveText("-");
+    const account = await testApp.account.textContent();
+
+    await testApp.reload();
+
+    await expect(testApp.state).toHaveText("signed in");
+    await expect(testApp.account).toHaveText(account ?? "");
+  });
+
+  test("SHARE-1: a second tab of the origin is already signed in", async ({
+    testApp,
+    openTestApp,
+    context,
+    identities,
+    signInWithIdentity,
+  }) => {
+    await testApp.open();
+    await testApp.signIn(
+      continueAs(identities[0].identityNumber, signInWithIdentity),
+    );
+    await expect(testApp.account).not.toHaveText("-");
+    const account = await testApp.account.textContent();
+
+    const second = openTestApp(await context.newPage());
+    await second.visit();
+
+    await expect(second.state).toHaveText("signed in");
+    await expect(second.account).toHaveText(account ?? "");
+    await second.close();
+  });
+
+  test("SHARE-2: signing out in one tab is noticed in the other", async ({
+    testApp,
+    openTestApp,
+    context,
+    identities,
+    signInWithIdentity,
+  }) => {
+    await testApp.open();
+    await testApp.signIn(
+      continueAs(identities[0].identityNumber, signInWithIdentity),
+    );
+
+    const second = openTestApp(await context.newPage());
+    await second.visit();
+    await expect(second.state).toHaveText("signed in");
+
+    await testApp.signOut();
+
+    await expect(second.state).toHaveText("no session");
+    await second.close();
+  });
+
+  test("SHARE-6: closing a tab does not disturb the others", async ({
+    testApp,
+    openTestApp,
+    context,
+    identities,
+    signInWithIdentity,
+  }) => {
+    await testApp.open();
+    await testApp.signIn(
+      continueAs(identities[0].identityNumber, signInWithIdentity),
+    );
+
+    const second = openTestApp(await context.newPage());
+    await second.visit();
+    await expect(second.state).toHaveText("signed in");
+    await second.close();
+
+    await testApp.replaceDelegation();
+    await expect(testApp.state).toHaveText("signed in");
+    await expect(testApp.delegation).not.toHaveText("none held");
+  });
+
+  test("EXIT-1: signing out of one app leaves the other alone", async ({
+    testApp,
+    openTestApp,
+    context,
+    identities,
+    signInWithIdentity,
+  }) => {
+    const authenticate = continueAs(
+      identities[0].identityNumber,
+      signInWithIdentity,
+    );
+    await testApp.open();
+    await testApp.signIn(authenticate);
+
+    const other = openTestApp(await context.newPage());
+    await other.open({ url: TEST_APP_CANONICAL_URL });
+    await other.signIn(authenticate);
+
+    await testApp.focus();
+    await testApp.signOut();
+    await expect(testApp.state).toHaveText("no session");
+
+    // Another origin is another account and another session.
+    await expect(other.state).toHaveText("signed in");
+    await other.close();
+  });
+
+  test("EXIT-6: signing out leaves nothing behind, across a reload", async ({
+    testApp,
+    identities,
+    signInWithIdentity,
+  }) => {
+    await testApp.open();
+    await testApp.signIn(
+      continueAs(identities[0].identityNumber, signInWithIdentity),
+    );
+
+    await testApp.signOut();
+    await expect(testApp.state).toHaveText("no session");
+
+    await testApp.reload();
+    await expect(testApp.state).toHaveText("no session");
+  });
+
+  test("a silent re-issue keeps the account and asks nothing", async ({
+    testApp,
+    identities,
+    signInWithIdentity,
+  }) => {
+    await testApp.open();
+    await testApp.signIn(
+      continueAs(identities[0].identityNumber, signInWithIdentity),
+    );
+    await expect(testApp.account).not.toHaveText("-");
+    const account = await testApp.account.textContent();
+
+    await testApp.silentReauth();
+
+    await expect(testApp.log).toContainText("silent re-auth", {
+      timeout: 30_000,
+    });
+    await expect(testApp.state).toHaveText("signed in");
+    await expect(testApp.account).toHaveText(account ?? "");
+  });
+
+  test("a silent re-issue with nothing to answer from fails one way", async ({
+    testApp,
+    identities,
+    signInWithIdentity,
+  }) => {
+    await testApp.open();
+    await testApp.signIn(
+      continueAs(identities[0].identityNumber, signInWithIdentity),
+    );
+    await testApp.signOut();
+    await expect(testApp.state).toHaveText("no session");
+
+    await testApp.silentReauth();
+
+    // FAIL-1 and SIL-2: one outcome, reported without asking the user anything,
+    // and nothing created. Windows are not counted: the window transport opens a
+    // channel either way, and SIL-1 is about screens, which the redirect
+    // transport the silent design targets is what makes checkable.
+    await expect(testApp.log).toContainText("error", { timeout: 30_000 });
+    await expect(testApp.state).toHaveText("no session");
+  });
+
+  test("STAY-2: clearing the site's data is a clean start", async ({
+    testApp,
+    identities,
+    signInWithIdentity,
+  }) => {
+    await testApp.open();
+    await testApp.signIn(
+      continueAs(identities[0].identityNumber, signInWithIdentity),
+    );
+
+    await testApp.clearSiteData();
+    await testApp.reload();
+
+    await expect(testApp.state).toHaveText("no session");
+  });
+
+  test("STAY-3: an interrupted sign-in can be retried", async ({
+    testApp,
+    identities,
+    signInWithIdentity,
+  }) => {
+    await testApp.open();
+    await testApp.abandonSignIn(async (authPage) => {
+      await signInWithIdentity(authPage, identities[0].identityNumber);
+    });
+    await expect(testApp.state).toHaveText("no session");
+
+    // DEV-13: the browser persisted its key before the call, so a second attempt
+    // is recognised as the same browser rather than blocked by the first.
+    await testApp.signIn(
+      continueAs(identities[0].identityNumber, signInWithIdentity),
+    );
+    await expect(testApp.state).toHaveText("signed in");
+  });
+
+  test.describe("with two identities", () => {
+    test.use({
+      identityConfig: {
+        createIdentities: [{ name: "First user" }, { name: "Second user" }],
+      },
+    });
+
+    test("STAY-4: two identities in one browser stay apart", async ({
+      testApp,
+      identities,
+      signInWithIdentity,
+    }) => {
+      await testApp.open();
+      await testApp.signIn(
+        continueAs(identities[0].identityNumber, signInWithIdentity),
+      );
+      await expect(testApp.account).not.toHaveText("-");
+      const first = await testApp.account.textContent();
+
+      await testApp.signOut();
+      await expect(testApp.state).toHaveText("no session");
+
+      await testApp.signIn(
+        continueAs(identities[1].identityNumber, signInWithIdentity),
+      );
+
+      await expect(testApp.account).not.toHaveText(first ?? "");
+    });
+  });
+
+  test.describe("across the siblings of a domain", () => {
+    test("SHARE-3: a sibling resumes from what the domain shares", async ({
+      testApp,
+      openTestApp,
+      context,
+      identities,
+      signInWithIdentity,
+    }) => {
+      await testApp.visit();
+      await testApp.declareAlternativeOrigins([
+        TEST_APP_SIBLING_A_URL,
+        TEST_APP_SIBLING_B_URL,
+      ]);
+
+      await testApp.open({
+        url: TEST_APP_SIBLING_A_URL,
+        derivationOrigin: TEST_APP_DERIVATION_ORIGIN,
+        cookieDomain: SHARED_DOMAIN,
+      });
+      await testApp.signIn(
+        continueAs(identities[0].identityNumber, signInWithIdentity),
+      );
+      const account = await testApp.account.textContent();
+
+      // HINT-1: what crosses between siblings names the account and an expiry.
+      await expect(testApp.sharedHint).not.toHaveText("none");
+      await expect(testApp.sharedHint).toContainText("until");
+
+      const other = openTestApp(await context.newPage());
+      await other.open({
+        url: TEST_APP_SIBLING_B_URL,
+        derivationOrigin: TEST_APP_DERIVATION_ORIGIN,
+        cookieDomain: SHARED_DOMAIN,
+      });
+      // Never signed in here, but the domain announces that a session exists.
+      await expect(other.sharedHint).not.toHaveText("none");
+      await expect(other.state).toHaveText("no session");
+
+      // SIL-5: it re-issues its own chain from the same session.
+      await other.silentReauth();
+      await expect(other.state).toHaveText("signed in", { timeout: 30_000 });
+      await expect(other.account).toHaveText(account ?? "");
+      await other.close();
+    });
+
+    test("SHARE-5: signing out on one subdomain signs the siblings out", async ({
+      testApp,
+      openTestApp,
+      context,
+      identities,
+      signInWithIdentity,
+    }) => {
+      await testApp.visit();
+      await testApp.declareAlternativeOrigins([
+        TEST_APP_SIBLING_A_URL,
+        TEST_APP_SIBLING_B_URL,
+      ]);
+
+      await testApp.open({
+        url: TEST_APP_SIBLING_A_URL,
+        derivationOrigin: TEST_APP_DERIVATION_ORIGIN,
+        cookieDomain: SHARED_DOMAIN,
+      });
+      await testApp.signIn(
+        continueAs(identities[0].identityNumber, signInWithIdentity),
+      );
+
+      const other = openTestApp(await context.newPage());
+      await other.open({
+        url: TEST_APP_SIBLING_B_URL,
+        derivationOrigin: TEST_APP_DERIVATION_ORIGIN,
+        cookieDomain: SHARED_DOMAIN,
+      });
+      await other.silentReauth();
+      await expect(other.state).toHaveText("signed in", { timeout: 30_000 });
+
+      // HINT-3: signing out retracts what the domain shares, so the sibling has
+      // nothing to resume from and asks the user instead.
+      await testApp.focus();
+      await testApp.signOut();
+      await expect(testApp.state).toHaveText("no session");
+
+      await other.focus();
+      await other.reload();
+      await expect(other.sharedHint).toHaveText("none", { timeout: 20_000 });
+      await expect(other.state).toHaveText("no session");
+      await other.close();
+    });
+  });
+
+  test.describe("through the identity's own settings", () => {
+    test("SHOW-2: the browser appears in the list after signing in", async ({
+      testApp,
+      context,
+      identities,
+      signInWithIdentity,
+    }) => {
+      await testApp.open();
+      await testApp.signIn(
+        continueAs(identities[0].identityNumber, signInWithIdentity),
+      );
+
+      const settings = await openSettings(
+        context,
+        identities[0].identityNumber,
+        signInWithIdentity,
+      );
+      await expect(
+        settings.getByRole("button", { name: "Sign out" }).first(),
+      ).toBeVisible();
+      await settings.close();
+    });
+
+    test("EXIT-3: signing the browser out from settings ends the app's access", async ({
+      testApp,
+      context,
+      identities,
+      signInWithIdentity,
+    }) => {
+      await testApp.open();
+      await testApp.signIn(
+        continueAs(identities[0].identityNumber, signInWithIdentity),
+      );
+
+      const settings = await openSettings(
+        context,
+        identities[0].identityNumber,
+        signInWithIdentity,
+      );
+      await settings.getByRole("button", { name: "Sign out" }).first().click();
+      await expect(settings.getByText("Signed out")).toBeVisible();
+      await settings.close();
+
+      // END-5 allows the app to keep working until the delegation it holds
+      // expires, so nothing shows until one is due. It is the mint that then
+      // discovers the session is gone.
+      await testApp.focus();
+      await testApp.ageDelegation();
+      await testApp.replaceDelegation();
+
+      await expect(testApp.state).toHaveText("no session", { timeout: 30_000 });
+    });
+
+    test("EXIT-5: a browser signed out is still the same browser", async ({
+      testApp,
+      context,
+      identities,
+      signInWithIdentity,
+    }) => {
+      const authenticate = continueAs(
+        identities[0].identityNumber,
+        signInWithIdentity,
+      );
+      await testApp.open();
+      await testApp.signIn(authenticate);
+
+      const settings = await openSettings(
+        context,
+        identities[0].identityNumber,
+        signInWithIdentity,
+      );
+      const listed = await settings
+        .getByRole("button", { name: "Sign out" })
+        .count();
+      await settings.getByRole("button", { name: "Sign out" }).first().click();
+      await expect(settings.getByText("Signed out")).toBeVisible();
+
+      // DEV-18: the entry stays, so signing in again reuses it.
+      await testApp.focus();
+      await testApp.signIn(authenticate);
+
+      // The page showing the list shared the browser it signed out, so reading
+      // the list again means signing in again — which is the same browser, and
+      // therefore the same entry.
+      await settings.close();
+      const listedAgain = await openSettings(
+        context,
+        identities[0].identityNumber,
+        signInWithIdentity,
+      );
+      await expect(
+        listedAgain.getByRole("button", { name: "Sign out" }),
+      ).toHaveCount(listed);
+      await listedAgain.close();
+    });
+
+    test("CAP-6: the list keeps the recent browsers and drops the rest", async ({
+      browser,
+      openTestApp,
+      identities,
+      signInWithIdentity,
+    }) => {
+      test.setTimeout(15 * 60 * 1000);
+      // A context is a separate browser as far as the identity is concerned, so
+      // the 20-entry cap is reachable without 20 machines.
+      const CAP = 20;
+      const browsers = [];
+      for (let index = 0; index < CAP + 2; index++) {
+        const fresh = await browser.newContext({ ignoreHTTPSErrors: true });
+        const app = openTestApp(await fresh.newPage());
+        await app.open();
+        await app.signIn(
+          continueAs(identities[0].identityNumber, signInWithIdentity),
+        );
+        browsers.push({ fresh, app });
+      }
+
+      // DEV-14: reaching the limit drops the least recently used rather than
+      // refusing, so the newest sign-in worked and the list is capped.
+      const settings = await openSettings(
+        browsers[browsers.length - 1].fresh,
+        identities[0].identityNumber,
+        signInWithIdentity,
+      );
+      const listed = await settings
+        .getByRole("button", { name: "Sign out" })
+        .count();
+      expect(listed).toBeLessThanOrEqual(CAP);
+
+      // DEV-15: dropping an entry ends that browser's sessions.
+      const oldest = browsers[0].app;
+      await oldest.focus();
+      await oldest.ageDelegation();
+      await oldest.replaceDelegation();
+      await expect(oldest.state).toHaveText("no session", { timeout: 30_000 });
+
+      for (const { fresh } of browsers) await fresh.close();
+    });
+  });
+});

--- a/src/frontend/tests/e2e-playwright/routes/authorize/app-sessions.spec.ts
+++ b/src/frontend/tests/e2e-playwright/routes/authorize/app-sessions.spec.ts
@@ -53,12 +53,11 @@ test.describe("app sessions", () => {
   test.use({ authorizeConfig: { protocol: "icrc25" } });
 
   test.describe("FIRST-1: a first sign-in leaves the app holding a session and a delegation", () => {
-    test.afterEach(async ({ testApp }) => {
-      await testApp.waitUntilSignedIn();
-      await expect(testApp.account).not.toHaveText("-");
+    test.afterEach(async ({ signedInApp }) => {
+      await expect(signedInApp.account).not.toHaveText("-");
       // The ceremony mints before it resolves, so a delegation is held straight
       // away rather than only once the tab next comes forward.
-      await expect(testApp.delegation).not.toHaveText("none held");
+      await expect(signedInApp.delegation).not.toHaveText("none held");
     });
 
     test("picks an identity and continues", async ({
@@ -74,18 +73,17 @@ test.describe("app sessions", () => {
   });
 
   test.describe("HOLD-1: the app keeps working for longer than one app delegation lasts", () => {
-    test.afterEach(async ({ testApp }) => {
-      await testApp.waitUntilSignedIn();
-      await expect(testApp.account).not.toHaveText("-");
-      const account = await testApp.account.textContent();
+    test.afterEach(async ({ signedInApp }) => {
+      await expect(signedInApp.account).not.toHaveText("-");
+      const account = await signedInApp.account.textContent();
 
-      await testApp.ageDelegation();
-      await testApp.replaceDelegation();
+      await signedInApp.ageDelegation();
+      await signedInApp.replaceDelegation();
 
-      await expect(testApp.state).toHaveText("signed in");
-      await expect(testApp.delegation).not.toHaveText("none held");
-      await expect(testApp.account).toHaveText(account ?? "");
-      await expect(testApp.replacements).not.toHaveText("0");
+      await expect(signedInApp.state).toHaveText("signed in");
+      await expect(signedInApp.delegation).not.toHaveText("none held");
+      await expect(signedInApp.account).toHaveText(account ?? "");
+      await expect(signedInApp.replacements).not.toHaveText("0");
     });
 
     test("picks an identity and continues", async ({
@@ -101,16 +99,15 @@ test.describe("app sessions", () => {
   });
 
   test.describe("HOLD-2: an app left open and untouched replaces nothing", () => {
-    test.afterEach(async ({ testApp }) => {
-      await testApp.waitUntilSignedIn();
-      await expect(testApp.replacements).toHaveText("0");
+    test.afterEach(async ({ signedInApp }) => {
+      await expect(signedInApp.replacements).toHaveText("0");
 
       // MINT-5 and MINT-14: the scheduled refresh cancels unless the delegation
       // it would replace signed a request, so an idle tab spends nothing.
-      await testApp.ageDelegation();
-      await testApp.page.waitForTimeout(1000);
+      await signedInApp.ageDelegation();
+      await signedInApp.page.waitForTimeout(1000);
 
-      await expect(testApp.replacements).toHaveText("0");
+      await expect(signedInApp.replacements).toHaveText("0");
     });
 
     test("picks an identity and continues", async ({
@@ -126,22 +123,21 @@ test.describe("app sessions", () => {
   });
 
   test.describe("HOLD-3: coming back to a tab replaces the delegation without being asked", () => {
-    test.afterEach(async ({ testApp }) => {
-      await testApp.waitUntilSignedIn();
-      await expect(testApp.replacements).toHaveText("0");
+    test.afterEach(async ({ signedInApp }) => {
+      await expect(signedInApp.replacements).toHaveText("0");
 
       // A delegation earns a replacement only once something used it (MINT-5).
-      await testApp.whoAmI();
+      await signedInApp.whoAmI();
 
       // MINT-7: the tab coming forward is the trigger; nothing is clicked to
       // mint.
-      await testApp.ageDelegation("04:55");
-      await testApp.returnToTab();
+      await signedInApp.ageDelegation("04:55");
+      await signedInApp.returnToTab();
 
-      await expect(testApp.replacements).not.toHaveText("0", {
+      await expect(signedInApp.replacements).not.toHaveText("0", {
         timeout: 30_000,
       });
-      await expect(testApp.state).toHaveText("signed in");
+      await expect(signedInApp.state).toHaveText("signed in");
     });
 
     test("picks an identity and continues", async ({
@@ -157,18 +153,17 @@ test.describe("app sessions", () => {
   });
 
   test.describe("HOLD-4: replacing the delegation renders nothing and keeps the account", () => {
-    test.afterEach(async ({ testApp }) => {
-      await testApp.waitUntilSignedIn();
-      await expect(testApp.account).not.toHaveText("-");
-      const account = await testApp.account.textContent();
-      const windowsBefore = testApp.openWindows;
+    test.afterEach(async ({ signedInApp }) => {
+      await expect(signedInApp.account).not.toHaveText("-");
+      const account = await signedInApp.account.textContent();
+      const windowsBefore = signedInApp.openWindows;
 
-      await testApp.replaceDelegation();
+      await signedInApp.replaceDelegation();
 
       // MINT-16: the account does not move. USE-6: nothing is rendered to do it.
-      await expect(testApp.account).toHaveText(account ?? "");
-      await expect(testApp.delegation).not.toHaveText("none held");
-      expect(testApp.openWindows).toBe(windowsBefore);
+      await expect(signedInApp.account).toHaveText(account ?? "");
+      await expect(signedInApp.delegation).not.toHaveText("none held");
+      expect(signedInApp.openWindows).toBe(windowsBefore);
     });
 
     test("picks an identity and continues", async ({
@@ -184,15 +179,14 @@ test.describe("app sessions", () => {
   });
 
   test.describe("HOLD-6: a reload comes back signed in, asking for nothing", () => {
-    test.afterEach(async ({ testApp }) => {
-      await testApp.waitUntilSignedIn();
-      await expect(testApp.account).not.toHaveText("-");
-      const account = await testApp.account.textContent();
+    test.afterEach(async ({ signedInApp }) => {
+      await expect(signedInApp.account).not.toHaveText("-");
+      const account = await signedInApp.account.textContent();
 
-      await testApp.reload();
+      await signedInApp.reload();
 
-      await expect(testApp.state).toHaveText("signed in");
-      await expect(testApp.account).toHaveText(account ?? "");
+      await expect(signedInApp.state).toHaveText("signed in");
+      await expect(signedInApp.account).toHaveText(account ?? "");
     });
 
     test("picks an identity and continues", async ({
@@ -208,10 +202,9 @@ test.describe("app sessions", () => {
   });
 
   test.describe("SHARE-1: a second tab of the origin is already signed in", () => {
-    test.afterEach(async ({ testApp, openTestApp, context }) => {
-      await testApp.waitUntilSignedIn();
-      await expect(testApp.account).not.toHaveText("-");
-      const account = await testApp.account.textContent();
+    test.afterEach(async ({ signedInApp, openTestApp, context }) => {
+      await expect(signedInApp.account).not.toHaveText("-");
+      const account = await signedInApp.account.textContent();
 
       const second = openTestApp(await context.newPage());
       await second.visit();
@@ -234,14 +227,12 @@ test.describe("app sessions", () => {
   });
 
   test.describe("SHARE-2: signing out in one tab is noticed in the other", () => {
-    test.afterEach(async ({ testApp, openTestApp, context }) => {
-      await testApp.waitUntilSignedIn();
-
+    test.afterEach(async ({ signedInApp, openTestApp, context }) => {
       const second = openTestApp(await context.newPage());
       await second.visit();
       await expect(second.state).toHaveText("signed in");
 
-      await testApp.signOut();
+      await signedInApp.signOut();
 
       await expect(second.state).toHaveText("no session");
       await second.close();
@@ -260,17 +251,15 @@ test.describe("app sessions", () => {
   });
 
   test.describe("SHARE-6: closing a tab does not disturb the others", () => {
-    test.afterEach(async ({ testApp, openTestApp, context }) => {
-      await testApp.waitUntilSignedIn();
-
+    test.afterEach(async ({ signedInApp, openTestApp, context }) => {
       const second = openTestApp(await context.newPage());
       await second.visit();
       await expect(second.state).toHaveText("signed in");
       await second.close();
 
-      await testApp.replaceDelegation();
-      await expect(testApp.state).toHaveText("signed in");
-      await expect(testApp.delegation).not.toHaveText("none held");
+      await signedInApp.replaceDelegation();
+      await expect(signedInApp.state).toHaveText("signed in");
+      await expect(signedInApp.delegation).not.toHaveText("none held");
     });
 
     test("picks an identity and continues", async ({
@@ -286,14 +275,12 @@ test.describe("app sessions", () => {
   });
 
   test.describe("EXIT-6: signing out leaves nothing behind, across a reload", () => {
-    test.afterEach(async ({ testApp }) => {
-      await testApp.waitUntilSignedIn();
+    test.afterEach(async ({ signedInApp }) => {
+      await signedInApp.signOut();
+      await expect(signedInApp.state).toHaveText("no session");
 
-      await testApp.signOut();
-      await expect(testApp.state).toHaveText("no session");
-
-      await testApp.reload();
-      await expect(testApp.state).toHaveText("no session");
+      await signedInApp.reload();
+      await expect(signedInApp.state).toHaveText("no session");
     });
 
     test("picks an identity and continues", async ({
@@ -309,18 +296,17 @@ test.describe("app sessions", () => {
   });
 
   test.describe("a silent re-issue keeps the account and asks nothing", () => {
-    test.afterEach(async ({ testApp }) => {
-      await testApp.waitUntilSignedIn();
-      await expect(testApp.account).not.toHaveText("-");
-      const account = await testApp.account.textContent();
+    test.afterEach(async ({ signedInApp }) => {
+      await expect(signedInApp.account).not.toHaveText("-");
+      const account = await signedInApp.account.textContent();
 
-      await testApp.silentReauth();
+      await signedInApp.silentReauth();
 
-      await expect(testApp.log).toContainText("silent re-auth", {
+      await expect(signedInApp.log).toContainText("silent re-auth", {
         timeout: 30_000,
       });
-      await expect(testApp.state).toHaveText("signed in");
-      await expect(testApp.account).toHaveText(account ?? "");
+      await expect(signedInApp.state).toHaveText("signed in");
+      await expect(signedInApp.account).toHaveText(account ?? "");
     });
 
     test("picks an identity and continues", async ({
@@ -336,20 +322,19 @@ test.describe("app sessions", () => {
   });
 
   test.describe("a silent re-issue with nothing to answer from fails one way", () => {
-    test.afterEach(async ({ testApp }) => {
-      await testApp.waitUntilSignedIn();
-      await testApp.signOut();
-      await expect(testApp.state).toHaveText("no session");
+    test.afterEach(async ({ signedInApp }) => {
+      await signedInApp.signOut();
+      await expect(signedInApp.state).toHaveText("no session");
 
-      await testApp.silentReauth();
+      await signedInApp.silentReauth();
 
       // FAIL-1 and SIL-2: one outcome, reported without asking the user
       // anything, and nothing created. Windows are not counted: the window
       // transport opens a channel either way, and SIL-1 is about screens, which
       // the redirect transport the silent design targets is what makes
       // checkable.
-      await expect(testApp.log).toContainText("error", { timeout: 30_000 });
-      await expect(testApp.state).toHaveText("no session");
+      await expect(signedInApp.log).toContainText("error", { timeout: 30_000 });
+      await expect(signedInApp.state).toHaveText("no session");
     });
 
     test("picks an identity and continues", async ({
@@ -365,13 +350,11 @@ test.describe("app sessions", () => {
   });
 
   test.describe("STAY-2: clearing the site's data is a clean start", () => {
-    test.afterEach(async ({ testApp }) => {
-      await testApp.waitUntilSignedIn();
+    test.afterEach(async ({ signedInApp }) => {
+      await signedInApp.clearSiteData();
+      await signedInApp.reload();
 
-      await testApp.clearSiteData();
-      await testApp.reload();
-
-      await expect(testApp.state).toHaveText("no session");
+      await expect(signedInApp.state).toHaveText("no session");
     });
 
     test("picks an identity and continues", async ({
@@ -390,7 +373,11 @@ test.describe("app sessions", () => {
     test.describe("SHOW-2: the browser appears in the list after signing in", () => {
       test.afterEach(
         async ({ testApp, context, identities, signInWithIdentity }) => {
+          // Stated here rather than taken from `signedInApp`, which this hook
+          // has nothing else to read: the row exists only once the sign-in has
+          // reached the canister.
           await testApp.waitUntilSignedIn();
+
           const settings = await openSettings(
             context,
             identities[0].identityNumber,
@@ -417,9 +404,7 @@ test.describe("app sessions", () => {
 
     test.describe("EXIT-3: signing the browser out from settings ends the app's access", () => {
       test.afterEach(
-        async ({ testApp, context, identities, signInWithIdentity }) => {
-          await testApp.waitUntilSignedIn();
-
+        async ({ signedInApp, context, identities, signInWithIdentity }) => {
           const settings = await openSettings(
             context,
             identities[0].identityNumber,
@@ -435,11 +420,11 @@ test.describe("app sessions", () => {
           // END-5 allows the app to keep working until the delegation it holds
           // expires, so nothing shows until one is due. It is the mint that then
           // discovers the session is gone.
-          await testApp.focus();
-          await testApp.ageDelegation();
-          await testApp.replaceDelegation();
+          await signedInApp.focus();
+          await signedInApp.ageDelegation();
+          await signedInApp.replaceDelegation();
 
-          await expect(testApp.state).toHaveText("no session", {
+          await expect(signedInApp.state).toHaveText("no session", {
             timeout: 30_000,
           });
         },

--- a/src/frontend/tests/e2e-playwright/routes/authorize/app-sessions.spec.ts
+++ b/src/frontend/tests/e2e-playwright/routes/authorize/app-sessions.spec.ts
@@ -46,21 +46,420 @@ const openSettings = async (
 const SHARED_DOMAIN = "nice-name.com";
 
 test.describe("app sessions", () => {
-  test("FIRST-1: a first sign-in leaves the app holding a session and a delegation", async ({
-    testApp,
-    identities,
-    signInWithIdentity,
-  }) => {
-    await testApp.open();
-    await testApp.signIn(
-      continueAs(identities[0].identityNumber, signInWithIdentity),
-    );
+  // Every scenario here starts from a sign-in over ICRC-25, which creates the
+  // session the rest of it is about. Where that is the only sign-in a scenario
+  // needs, `authorizePage` performs it: the body is then the identity provider's
+  // side of the ceremony, and the app is read in `afterEach`.
+  test.use({ authorizeConfig: { protocol: "icrc25" } });
 
-    await expect(testApp.account).not.toHaveText("-");
-    // The ceremony mints before it resolves, so a delegation is held straight
-    // away rather than only once the tab next comes forward.
-    await expect(testApp.delegation).not.toHaveText("none held");
+  test.describe("FIRST-1: a first sign-in leaves the app holding a session and a delegation", () => {
+    test.afterEach(async ({ testApp }) => {
+      await testApp.waitUntilSignedIn();
+      await expect(testApp.account).not.toHaveText("-");
+      // The ceremony mints before it resolves, so a delegation is held straight
+      // away rather than only once the tab next comes forward.
+      await expect(testApp.delegation).not.toHaveText("none held");
+    });
+
+    test("picks an identity and continues", async ({
+      authorizePage,
+      identities,
+      signInWithIdentity,
+    }) => {
+      await continueAs(
+        identities[0].identityNumber,
+        signInWithIdentity,
+      )(authorizePage.page);
+    });
   });
+
+  test.describe("HOLD-1: the app keeps working for longer than one app delegation lasts", () => {
+    test.afterEach(async ({ testApp }) => {
+      await testApp.waitUntilSignedIn();
+      await expect(testApp.account).not.toHaveText("-");
+      const account = await testApp.account.textContent();
+
+      await testApp.ageDelegation();
+      await testApp.replaceDelegation();
+
+      await expect(testApp.state).toHaveText("signed in");
+      await expect(testApp.delegation).not.toHaveText("none held");
+      await expect(testApp.account).toHaveText(account ?? "");
+      await expect(testApp.replacements).not.toHaveText("0");
+    });
+
+    test("picks an identity and continues", async ({
+      authorizePage,
+      identities,
+      signInWithIdentity,
+    }) => {
+      await continueAs(
+        identities[0].identityNumber,
+        signInWithIdentity,
+      )(authorizePage.page);
+    });
+  });
+
+  test.describe("HOLD-2: an app left open and untouched replaces nothing", () => {
+    test.afterEach(async ({ testApp }) => {
+      await testApp.waitUntilSignedIn();
+      await expect(testApp.replacements).toHaveText("0");
+
+      // MINT-5 and MINT-14: the scheduled refresh cancels unless the delegation
+      // it would replace signed a request, so an idle tab spends nothing.
+      await testApp.ageDelegation();
+      await testApp.page.waitForTimeout(1000);
+
+      await expect(testApp.replacements).toHaveText("0");
+    });
+
+    test("picks an identity and continues", async ({
+      authorizePage,
+      identities,
+      signInWithIdentity,
+    }) => {
+      await continueAs(
+        identities[0].identityNumber,
+        signInWithIdentity,
+      )(authorizePage.page);
+    });
+  });
+
+  test.describe("HOLD-3: coming back to a tab replaces the delegation without being asked", () => {
+    test.afterEach(async ({ testApp }) => {
+      await testApp.waitUntilSignedIn();
+      await expect(testApp.replacements).toHaveText("0");
+
+      // A delegation earns a replacement only once something used it (MINT-5).
+      await testApp.whoAmI();
+
+      // MINT-7: the tab coming forward is the trigger; nothing is clicked to
+      // mint.
+      await testApp.ageDelegation("04:55");
+      await testApp.returnToTab();
+
+      await expect(testApp.replacements).not.toHaveText("0", {
+        timeout: 30_000,
+      });
+      await expect(testApp.state).toHaveText("signed in");
+    });
+
+    test("picks an identity and continues", async ({
+      authorizePage,
+      identities,
+      signInWithIdentity,
+    }) => {
+      await continueAs(
+        identities[0].identityNumber,
+        signInWithIdentity,
+      )(authorizePage.page);
+    });
+  });
+
+  test.describe("HOLD-4: replacing the delegation renders nothing and keeps the account", () => {
+    test.afterEach(async ({ testApp }) => {
+      await testApp.waitUntilSignedIn();
+      await expect(testApp.account).not.toHaveText("-");
+      const account = await testApp.account.textContent();
+      const windowsBefore = testApp.openWindows;
+
+      await testApp.replaceDelegation();
+
+      // MINT-16: the account does not move. USE-6: nothing is rendered to do it.
+      await expect(testApp.account).toHaveText(account ?? "");
+      await expect(testApp.delegation).not.toHaveText("none held");
+      expect(testApp.openWindows).toBe(windowsBefore);
+    });
+
+    test("picks an identity and continues", async ({
+      authorizePage,
+      identities,
+      signInWithIdentity,
+    }) => {
+      await continueAs(
+        identities[0].identityNumber,
+        signInWithIdentity,
+      )(authorizePage.page);
+    });
+  });
+
+  test.describe("HOLD-6: a reload comes back signed in, asking for nothing", () => {
+    test.afterEach(async ({ testApp }) => {
+      await testApp.waitUntilSignedIn();
+      await expect(testApp.account).not.toHaveText("-");
+      const account = await testApp.account.textContent();
+
+      await testApp.reload();
+
+      await expect(testApp.state).toHaveText("signed in");
+      await expect(testApp.account).toHaveText(account ?? "");
+    });
+
+    test("picks an identity and continues", async ({
+      authorizePage,
+      identities,
+      signInWithIdentity,
+    }) => {
+      await continueAs(
+        identities[0].identityNumber,
+        signInWithIdentity,
+      )(authorizePage.page);
+    });
+  });
+
+  test.describe("SHARE-1: a second tab of the origin is already signed in", () => {
+    test.afterEach(async ({ testApp, openTestApp, context }) => {
+      await testApp.waitUntilSignedIn();
+      await expect(testApp.account).not.toHaveText("-");
+      const account = await testApp.account.textContent();
+
+      const second = openTestApp(await context.newPage());
+      await second.visit();
+
+      await expect(second.state).toHaveText("signed in");
+      await expect(second.account).toHaveText(account ?? "");
+      await second.close();
+    });
+
+    test("picks an identity and continues", async ({
+      authorizePage,
+      identities,
+      signInWithIdentity,
+    }) => {
+      await continueAs(
+        identities[0].identityNumber,
+        signInWithIdentity,
+      )(authorizePage.page);
+    });
+  });
+
+  test.describe("SHARE-2: signing out in one tab is noticed in the other", () => {
+    test.afterEach(async ({ testApp, openTestApp, context }) => {
+      await testApp.waitUntilSignedIn();
+
+      const second = openTestApp(await context.newPage());
+      await second.visit();
+      await expect(second.state).toHaveText("signed in");
+
+      await testApp.signOut();
+
+      await expect(second.state).toHaveText("no session");
+      await second.close();
+    });
+
+    test("picks an identity and continues", async ({
+      authorizePage,
+      identities,
+      signInWithIdentity,
+    }) => {
+      await continueAs(
+        identities[0].identityNumber,
+        signInWithIdentity,
+      )(authorizePage.page);
+    });
+  });
+
+  test.describe("SHARE-6: closing a tab does not disturb the others", () => {
+    test.afterEach(async ({ testApp, openTestApp, context }) => {
+      await testApp.waitUntilSignedIn();
+
+      const second = openTestApp(await context.newPage());
+      await second.visit();
+      await expect(second.state).toHaveText("signed in");
+      await second.close();
+
+      await testApp.replaceDelegation();
+      await expect(testApp.state).toHaveText("signed in");
+      await expect(testApp.delegation).not.toHaveText("none held");
+    });
+
+    test("picks an identity and continues", async ({
+      authorizePage,
+      identities,
+      signInWithIdentity,
+    }) => {
+      await continueAs(
+        identities[0].identityNumber,
+        signInWithIdentity,
+      )(authorizePage.page);
+    });
+  });
+
+  test.describe("EXIT-6: signing out leaves nothing behind, across a reload", () => {
+    test.afterEach(async ({ testApp }) => {
+      await testApp.waitUntilSignedIn();
+
+      await testApp.signOut();
+      await expect(testApp.state).toHaveText("no session");
+
+      await testApp.reload();
+      await expect(testApp.state).toHaveText("no session");
+    });
+
+    test("picks an identity and continues", async ({
+      authorizePage,
+      identities,
+      signInWithIdentity,
+    }) => {
+      await continueAs(
+        identities[0].identityNumber,
+        signInWithIdentity,
+      )(authorizePage.page);
+    });
+  });
+
+  test.describe("a silent re-issue keeps the account and asks nothing", () => {
+    test.afterEach(async ({ testApp }) => {
+      await testApp.waitUntilSignedIn();
+      await expect(testApp.account).not.toHaveText("-");
+      const account = await testApp.account.textContent();
+
+      await testApp.silentReauth();
+
+      await expect(testApp.log).toContainText("silent re-auth", {
+        timeout: 30_000,
+      });
+      await expect(testApp.state).toHaveText("signed in");
+      await expect(testApp.account).toHaveText(account ?? "");
+    });
+
+    test("picks an identity and continues", async ({
+      authorizePage,
+      identities,
+      signInWithIdentity,
+    }) => {
+      await continueAs(
+        identities[0].identityNumber,
+        signInWithIdentity,
+      )(authorizePage.page);
+    });
+  });
+
+  test.describe("a silent re-issue with nothing to answer from fails one way", () => {
+    test.afterEach(async ({ testApp }) => {
+      await testApp.waitUntilSignedIn();
+      await testApp.signOut();
+      await expect(testApp.state).toHaveText("no session");
+
+      await testApp.silentReauth();
+
+      // FAIL-1 and SIL-2: one outcome, reported without asking the user
+      // anything, and nothing created. Windows are not counted: the window
+      // transport opens a channel either way, and SIL-1 is about screens, which
+      // the redirect transport the silent design targets is what makes
+      // checkable.
+      await expect(testApp.log).toContainText("error", { timeout: 30_000 });
+      await expect(testApp.state).toHaveText("no session");
+    });
+
+    test("picks an identity and continues", async ({
+      authorizePage,
+      identities,
+      signInWithIdentity,
+    }) => {
+      await continueAs(
+        identities[0].identityNumber,
+        signInWithIdentity,
+      )(authorizePage.page);
+    });
+  });
+
+  test.describe("STAY-2: clearing the site's data is a clean start", () => {
+    test.afterEach(async ({ testApp }) => {
+      await testApp.waitUntilSignedIn();
+
+      await testApp.clearSiteData();
+      await testApp.reload();
+
+      await expect(testApp.state).toHaveText("no session");
+    });
+
+    test("picks an identity and continues", async ({
+      authorizePage,
+      identities,
+      signInWithIdentity,
+    }) => {
+      await continueAs(
+        identities[0].identityNumber,
+        signInWithIdentity,
+      )(authorizePage.page);
+    });
+  });
+
+  test.describe("through the identity's own settings", () => {
+    test.describe("SHOW-2: the browser appears in the list after signing in", () => {
+      test.afterEach(
+        async ({ testApp, context, identities, signInWithIdentity }) => {
+          await testApp.waitUntilSignedIn();
+          const settings = await openSettings(
+            context,
+            identities[0].identityNumber,
+            signInWithIdentity,
+          );
+          await expect(
+            settings.getByRole("button", { name: "Sign out" }).first(),
+          ).toBeVisible();
+          await settings.close();
+        },
+      );
+
+      test("picks an identity and continues", async ({
+        authorizePage,
+        identities,
+        signInWithIdentity,
+      }) => {
+        await continueAs(
+          identities[0].identityNumber,
+          signInWithIdentity,
+        )(authorizePage.page);
+      });
+    });
+
+    test.describe("EXIT-3: signing the browser out from settings ends the app's access", () => {
+      test.afterEach(
+        async ({ testApp, context, identities, signInWithIdentity }) => {
+          await testApp.waitUntilSignedIn();
+
+          const settings = await openSettings(
+            context,
+            identities[0].identityNumber,
+            signInWithIdentity,
+          );
+          await settings
+            .getByRole("button", { name: "Sign out" })
+            .first()
+            .click();
+          await expect(settings.getByText("Signed out")).toBeVisible();
+          await settings.close();
+
+          // END-5 allows the app to keep working until the delegation it holds
+          // expires, so nothing shows until one is due. It is the mint that then
+          // discovers the session is gone.
+          await testApp.focus();
+          await testApp.ageDelegation();
+          await testApp.replaceDelegation();
+
+          await expect(testApp.state).toHaveText("no session", {
+            timeout: 30_000,
+          });
+        },
+      );
+
+      test("picks an identity and continues", async ({
+        authorizePage,
+        identities,
+        signInWithIdentity,
+      }) => {
+        await continueAs(
+          identities[0].identityNumber,
+          signInWithIdentity,
+        )(authorizePage.page);
+      });
+    });
+  });
+
+  // The scenarios below sign in more than once, or need the app configured in a
+  // way `authorizeConfig` does not describe, so they drive the app themselves.
 
   test("one identity is a different account at each app", async ({
     testApp,
@@ -106,173 +505,6 @@ test.describe("app sessions", () => {
     await expect(testApp.sessionKey).not.toHaveText(before ?? "");
   });
 
-  test("HOLD-1: the app keeps working for longer than one app delegation lasts", async ({
-    testApp,
-    identities,
-    signInWithIdentity,
-  }) => {
-    await testApp.open();
-    await testApp.signIn(
-      continueAs(identities[0].identityNumber, signInWithIdentity),
-    );
-    await expect(testApp.account).not.toHaveText("-");
-    const account = await testApp.account.textContent();
-
-    await testApp.ageDelegation();
-    await testApp.replaceDelegation();
-
-    await expect(testApp.state).toHaveText("signed in");
-    await expect(testApp.delegation).not.toHaveText("none held");
-    await expect(testApp.account).toHaveText(account ?? "");
-    await expect(testApp.replacements).not.toHaveText("0");
-  });
-
-  test("HOLD-2: an app left open and untouched replaces nothing", async ({
-    testApp,
-    identities,
-    signInWithIdentity,
-  }) => {
-    await testApp.open();
-    await testApp.signIn(
-      continueAs(identities[0].identityNumber, signInWithIdentity),
-    );
-    await expect(testApp.replacements).toHaveText("0");
-
-    // MINT-5 and MINT-14: the scheduled refresh cancels unless the delegation it
-    // would replace signed a request, so an idle tab spends nothing.
-    await testApp.ageDelegation();
-    await testApp.page.waitForTimeout(1000);
-
-    await expect(testApp.replacements).toHaveText("0");
-  });
-
-  test("HOLD-3: coming back to a tab replaces the delegation without being asked", async ({
-    testApp,
-    identities,
-    signInWithIdentity,
-  }) => {
-    await testApp.open();
-    await testApp.signIn(
-      continueAs(identities[0].identityNumber, signInWithIdentity),
-    );
-    await expect(testApp.replacements).toHaveText("0");
-
-    // A delegation earns a replacement only once something used it (MINT-5).
-    await testApp.whoAmI();
-
-    // MINT-7: the tab coming forward is the trigger; nothing is clicked to mint.
-    await testApp.ageDelegation("04:55");
-    await testApp.returnToTab();
-
-    await expect(testApp.replacements).not.toHaveText("0", { timeout: 30_000 });
-    await expect(testApp.state).toHaveText("signed in");
-  });
-
-  test("HOLD-4: replacing the delegation renders nothing and keeps the account", async ({
-    testApp,
-    identities,
-    signInWithIdentity,
-  }) => {
-    await testApp.open();
-    await testApp.signIn(
-      continueAs(identities[0].identityNumber, signInWithIdentity),
-    );
-    await expect(testApp.account).not.toHaveText("-");
-    const account = await testApp.account.textContent();
-    const windowsBefore = testApp.openWindows;
-
-    await testApp.replaceDelegation();
-
-    // MINT-16: the account does not move. USE-6: nothing is rendered to do it.
-    await expect(testApp.account).toHaveText(account ?? "");
-    await expect(testApp.delegation).not.toHaveText("none held");
-    expect(testApp.openWindows).toBe(windowsBefore);
-  });
-
-  test("HOLD-6: a reload comes back signed in, asking for nothing", async ({
-    testApp,
-    identities,
-    signInWithIdentity,
-  }) => {
-    await testApp.open();
-    await testApp.signIn(
-      continueAs(identities[0].identityNumber, signInWithIdentity),
-    );
-    await expect(testApp.account).not.toHaveText("-");
-    const account = await testApp.account.textContent();
-
-    await testApp.reload();
-
-    await expect(testApp.state).toHaveText("signed in");
-    await expect(testApp.account).toHaveText(account ?? "");
-  });
-
-  test("SHARE-1: a second tab of the origin is already signed in", async ({
-    testApp,
-    openTestApp,
-    context,
-    identities,
-    signInWithIdentity,
-  }) => {
-    await testApp.open();
-    await testApp.signIn(
-      continueAs(identities[0].identityNumber, signInWithIdentity),
-    );
-    await expect(testApp.account).not.toHaveText("-");
-    const account = await testApp.account.textContent();
-
-    const second = openTestApp(await context.newPage());
-    await second.visit();
-
-    await expect(second.state).toHaveText("signed in");
-    await expect(second.account).toHaveText(account ?? "");
-    await second.close();
-  });
-
-  test("SHARE-2: signing out in one tab is noticed in the other", async ({
-    testApp,
-    openTestApp,
-    context,
-    identities,
-    signInWithIdentity,
-  }) => {
-    await testApp.open();
-    await testApp.signIn(
-      continueAs(identities[0].identityNumber, signInWithIdentity),
-    );
-
-    const second = openTestApp(await context.newPage());
-    await second.visit();
-    await expect(second.state).toHaveText("signed in");
-
-    await testApp.signOut();
-
-    await expect(second.state).toHaveText("no session");
-    await second.close();
-  });
-
-  test("SHARE-6: closing a tab does not disturb the others", async ({
-    testApp,
-    openTestApp,
-    context,
-    identities,
-    signInWithIdentity,
-  }) => {
-    await testApp.open();
-    await testApp.signIn(
-      continueAs(identities[0].identityNumber, signInWithIdentity),
-    );
-
-    const second = openTestApp(await context.newPage());
-    await second.visit();
-    await expect(second.state).toHaveText("signed in");
-    await second.close();
-
-    await testApp.replaceDelegation();
-    await expect(testApp.state).toHaveText("signed in");
-    await expect(testApp.delegation).not.toHaveText("none held");
-  });
-
   test("EXIT-1: signing out of one app leaves the other alone", async ({
     testApp,
     openTestApp,
@@ -298,82 +530,6 @@ test.describe("app sessions", () => {
     // Another origin is another account and another session.
     await expect(other.state).toHaveText("signed in");
     await other.close();
-  });
-
-  test("EXIT-6: signing out leaves nothing behind, across a reload", async ({
-    testApp,
-    identities,
-    signInWithIdentity,
-  }) => {
-    await testApp.open();
-    await testApp.signIn(
-      continueAs(identities[0].identityNumber, signInWithIdentity),
-    );
-
-    await testApp.signOut();
-    await expect(testApp.state).toHaveText("no session");
-
-    await testApp.reload();
-    await expect(testApp.state).toHaveText("no session");
-  });
-
-  test("a silent re-issue keeps the account and asks nothing", async ({
-    testApp,
-    identities,
-    signInWithIdentity,
-  }) => {
-    await testApp.open();
-    await testApp.signIn(
-      continueAs(identities[0].identityNumber, signInWithIdentity),
-    );
-    await expect(testApp.account).not.toHaveText("-");
-    const account = await testApp.account.textContent();
-
-    await testApp.silentReauth();
-
-    await expect(testApp.log).toContainText("silent re-auth", {
-      timeout: 30_000,
-    });
-    await expect(testApp.state).toHaveText("signed in");
-    await expect(testApp.account).toHaveText(account ?? "");
-  });
-
-  test("a silent re-issue with nothing to answer from fails one way", async ({
-    testApp,
-    identities,
-    signInWithIdentity,
-  }) => {
-    await testApp.open();
-    await testApp.signIn(
-      continueAs(identities[0].identityNumber, signInWithIdentity),
-    );
-    await testApp.signOut();
-    await expect(testApp.state).toHaveText("no session");
-
-    await testApp.silentReauth();
-
-    // FAIL-1 and SIL-2: one outcome, reported without asking the user anything,
-    // and nothing created. Windows are not counted: the window transport opens a
-    // channel either way, and SIL-1 is about screens, which the redirect
-    // transport the silent design targets is what makes checkable.
-    await expect(testApp.log).toContainText("error", { timeout: 30_000 });
-    await expect(testApp.state).toHaveText("no session");
-  });
-
-  test("STAY-2: clearing the site's data is a clean start", async ({
-    testApp,
-    identities,
-    signInWithIdentity,
-  }) => {
-    await testApp.open();
-    await testApp.signIn(
-      continueAs(identities[0].identityNumber, signInWithIdentity),
-    );
-
-    await testApp.clearSiteData();
-    await testApp.reload();
-
-    await expect(testApp.state).toHaveText("no session");
   });
 
   test("STAY-3: an interrupted sign-in can be retried", async ({
@@ -515,59 +671,7 @@ test.describe("app sessions", () => {
     });
   });
 
-  test.describe("through the identity's own settings", () => {
-    test("SHOW-2: the browser appears in the list after signing in", async ({
-      testApp,
-      context,
-      identities,
-      signInWithIdentity,
-    }) => {
-      await testApp.open();
-      await testApp.signIn(
-        continueAs(identities[0].identityNumber, signInWithIdentity),
-      );
-
-      const settings = await openSettings(
-        context,
-        identities[0].identityNumber,
-        signInWithIdentity,
-      );
-      await expect(
-        settings.getByRole("button", { name: "Sign out" }).first(),
-      ).toBeVisible();
-      await settings.close();
-    });
-
-    test("EXIT-3: signing the browser out from settings ends the app's access", async ({
-      testApp,
-      context,
-      identities,
-      signInWithIdentity,
-    }) => {
-      await testApp.open();
-      await testApp.signIn(
-        continueAs(identities[0].identityNumber, signInWithIdentity),
-      );
-
-      const settings = await openSettings(
-        context,
-        identities[0].identityNumber,
-        signInWithIdentity,
-      );
-      await settings.getByRole("button", { name: "Sign out" }).first().click();
-      await expect(settings.getByText("Signed out")).toBeVisible();
-      await settings.close();
-
-      // END-5 allows the app to keep working until the delegation it holds
-      // expires, so nothing shows until one is due. It is the mint that then
-      // discovers the session is gone.
-      await testApp.focus();
-      await testApp.ageDelegation();
-      await testApp.replaceDelegation();
-
-      await expect(testApp.state).toHaveText("no session", { timeout: 30_000 });
-    });
-
+  test.describe("more sign-ins than the identity keeps", () => {
     test("EXIT-5: a browser signed out is still the same browser", async ({
       testApp,
       context,

--- a/src/frontend/tests/e2e-playwright/routes/authorize/delegationTtl.spec.ts
+++ b/src/frontend/tests/e2e-playwright/routes/authorize/delegationTtl.spec.ts
@@ -1,9 +1,10 @@
 import { expect, test } from "@playwright/test";
-import { addVirtualAuthenticator, II_URL, TEST_APP_URL } from "../../utils";
+import { addVirtualAuthenticator, II_URL, TEST_APP_URL, useLegacyProtocol } from "../../utils";
 
 test("Delegation maxTimeToLive: 1 min", async ({ page }) => {
   // Open demo app and configure II URL
   await page.goto(TEST_APP_URL);
+  await useLegacyProtocol(page);
   await page.getByRole("textbox", { name: "Identity Provider" }).fill(II_URL);
 
   // Set maxTimeToLive to 1 minute (60 seconds = 60_000_000_000 nanoseconds)
@@ -38,6 +39,7 @@ test("Delegation maxTimeToLive: 1 min", async ({ page }) => {
 test("Delegation maxTimeToLive: 1 day", async ({ page }) => {
   // Open demo app and configure II URL
   await page.goto(TEST_APP_URL);
+  await useLegacyProtocol(page);
   await page.getByRole("textbox", { name: "Identity Provider" }).fill(II_URL);
 
   // Set maxTimeToLive to 1 day (86400 seconds = 86400_000_000_000 nanoseconds)
@@ -71,6 +73,7 @@ test("Delegation maxTimeToLive: 1 day", async ({ page }) => {
 test("Delegation maxTimeToLive: 2 months", async ({ page }) => {
   // Open demo app and configure II URL
   await page.goto(TEST_APP_URL);
+  await useLegacyProtocol(page);
   await page.getByRole("textbox", { name: "Identity Provider" }).fill(II_URL);
 
   // Set maxTimeToLive to 60 days (5_184_000_000_000_000 nanoseconds)

--- a/src/frontend/tests/e2e-playwright/routes/authorize/manage-identity.spec.ts
+++ b/src/frontend/tests/e2e-playwright/routes/authorize/manage-identity.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from "@playwright/test";
 import { test } from "../../fixtures";
-import { authorize, II_URL, TEST_APP_URL } from "../../utils";
+import { authorize, II_URL, TEST_APP_URL, useLegacyProtocol } from "../../utils";
 
 test.describe("Manage your Internet Identity from authorize popover", () => {
   test("postMessage handoff — manage tab lands on /manage without sign-in dialog", async ({
@@ -11,6 +11,7 @@ test.describe("Manage your Internet Identity from authorize popover", () => {
   }) => {
     // Establish a last-used identity by completing an authorize flow first.
     await page.goto(TEST_APP_URL);
+  await useLegacyProtocol(page);
     await page.getByRole("textbox", { name: "Identity Provider" }).fill(II_URL);
 
     await authorize(page, async (authPage) => {

--- a/src/frontend/tests/e2e-playwright/routes/authorize/session-delegation.spec.ts
+++ b/src/frontend/tests/e2e-playwright/routes/authorize/session-delegation.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from "@playwright/test";
 import { test } from "../../fixtures";
-import { authorize, TEST_APP_URL, II_URL } from "../../utils";
+import { authorize, TEST_APP_URL, II_URL, useLegacyProtocol } from "../../utils";
 
 test.describe("session delegation — multiple accounts without re-auth", () => {
   test("after sign-in, reloading authorize and toggling multiple accounts loads accounts without WebAuthn ceremony", async ({
@@ -18,6 +18,7 @@ test.describe("session delegation — multiple accounts without re-auth", () => 
 
     const authPagePromise = page.context().waitForEvent("page");
     await page.goto(TEST_APP_URL);
+  await useLegacyProtocol(page);
     await page.getByRole("textbox", { name: "Identity Provider" }).fill(II_URL);
     await page.getByRole("button", { name: "Sign In" }).click();
     const authPage = await authPagePromise;

--- a/src/frontend/tests/e2e-playwright/routes/authorize/sso.spec.ts
+++ b/src/frontend/tests/e2e-playwright/routes/authorize/sso.spec.ts
@@ -579,7 +579,7 @@ test.describe("Authorize with IdP-side per-app gating", () => {
         .getByRole("textbox", { name: "Identity Provider" })
         .fill(ssoUrl);
       await page
-        .getByRole("checkbox", { name: "Use ICRC-25 protocol:" })
+        .getByRole("checkbox", { name: "Use ICRC-25 and sessions:" })
         .setChecked(true);
       await page
         .getByRole("checkbox", { name: "Use ICRC-3 attributes:" })
@@ -686,7 +686,7 @@ test.describe("Authorize with IdP-side per-app gating", () => {
         .getByRole("textbox", { name: "Identity Provider" })
         .fill(ssoUrl);
       await page
-        .getByRole("checkbox", { name: "Use ICRC-25 protocol:" })
+        .getByRole("checkbox", { name: "Use ICRC-25 and sessions:" })
         .setChecked(true);
       await page
         .getByRole("checkbox", { name: "Use ICRC-3 attributes:" })
@@ -783,7 +783,7 @@ test.describe("Authorize with IdP-side per-app gating", () => {
         .getByRole("textbox", { name: "Identity Provider" })
         .fill(ssoUrl);
       await page
-        .getByRole("checkbox", { name: "Use ICRC-25 protocol:" })
+        .getByRole("checkbox", { name: "Use ICRC-25 and sessions:" })
         .setChecked(true);
       await expect(page.locator("#principal")).toBeHidden();
       const popupPromise = page.context().waitForEvent("page");
@@ -968,7 +968,7 @@ test.describe("Continue as a last-used SSO identity", () => {
       .getByRole("textbox", { name: "Identity Provider" })
       .fill(II_URL + "/authorize");
     await page
-      .getByRole("checkbox", { name: "Use ICRC-25 protocol:" })
+      .getByRole("checkbox", { name: "Use ICRC-25 and sessions:" })
       .setChecked(true);
     await page
       .getByRole("checkbox", { name: "Use ICRC-3 attributes:" })
@@ -1056,7 +1056,7 @@ test.describe("Authorize with gated non-sub (Entra) SSO", () => {
     await page.goto(GATED_ORIGIN);
     await page.getByRole("textbox", { name: "Identity Provider" }).fill(ssoUrl);
     await page
-      .getByRole("checkbox", { name: "Use ICRC-25 protocol:" })
+      .getByRole("checkbox", { name: "Use ICRC-25 and sessions:" })
       .setChecked(true);
     await expect(page.locator("#principal")).toBeHidden();
     const popupPromise = page.context().waitForEvent("page");
@@ -1149,7 +1149,7 @@ test.describe("Authorize with gated non-sub (Entra) SSO", () => {
     await page.goto(GATED_ORIGIN);
     await page.getByRole("textbox", { name: "Identity Provider" }).fill(ssoUrl);
     await page
-      .getByRole("checkbox", { name: "Use ICRC-25 protocol:" })
+      .getByRole("checkbox", { name: "Use ICRC-25 and sessions:" })
       .setChecked(true);
     await expect(page.locator("#principal")).toBeHidden();
     const popup2Promise = page.context().waitForEvent("page");

--- a/src/frontend/tests/e2e-playwright/utils.ts
+++ b/src/frontend/tests/e2e-playwright/utils.ts
@@ -17,10 +17,15 @@ import { _SERVICE } from "$lib/generated/internet_identity_types";
 import { idlFactory as internet_identity_idl } from "$lib/generated/internet_identity_idl";
 
 const testAppCanisterId = readCanisterId({ canisterName: "test_app" });
+const iiCanisterId = readCanisterId({ canisterName: "internet_identity" });
 export const II_URL = "https://id.ai";
 export const LEGACY_II_URL = "https://identity.ic0.app";
 export const ALT_LEGACY_II_URL = "https://identity.internetcomputer.org";
 export const TEST_APP_URL = "https://nice-name.com";
+/** Siblings of one domain, sharing `TEST_APP_DERIVATION_ORIGIN`. */
+export const TEST_APP_SIBLING_A_URL = "https://a.nice-name.com";
+export const TEST_APP_SIBLING_B_URL = "https://b.nice-name.com";
+export const TEST_APP_DERIVATION_ORIGIN = "https://auth.nice-name.com";
 export const NOT_TEST_APP_URL = "https://very-nice-name.com";
 export const TEST_APP_CANONICAL_URL = `https://${testAppCanisterId}.icp0.io`;
 
@@ -70,6 +75,19 @@ export const authorize = (
  * @param authenticate The method that will be called within authorize page
  * @returns Authenticated principal
  */
+/**
+ * Selects the raw postMessage protocol, which creates no session.
+ *
+ * The test app defaults to the session path, so a test that drives it directly
+ * has to say which protocol it means rather than inherit whichever the app
+ * happens to prefer.
+ */
+export const useLegacyProtocol = async (page: Page): Promise<void> => {
+  await page
+    .getByRole("checkbox", { name: "Use ICRC-25 and sessions:" })
+    .setChecked(false);
+};
+
 export const authorizeWithUrl = async (
   page: Page,
   appUrl: string,
@@ -81,10 +99,18 @@ export const authorizeWithUrl = async (
   // Open demo app and assert that user isn't authenticated yet
   await page.goto(appUrl);
   await page.getByRole("textbox", { name: "Identity Provider" }).fill(iiURL);
+  // Set either way rather than relying on the test app's default, which selects
+  // the session path and would otherwise decide this for every caller.
+  await page
+    .getByRole("checkbox", { name: "Use ICRC-25 and sessions:" })
+    .setChecked(useIcrc25 === true);
   if (useIcrc25 === true) {
+    // The session the client is handed is restricted to one identity provider,
+    // and the client refuses a chain that names any other. Its default is the
+    // mainnet canister, so a local sign-in needs this filled in.
     await page
-      .getByRole("checkbox", { name: "Use ICRC-25 protocol:" })
-      .setChecked(true);
+      .getByRole("textbox", { name: "II canister id:" })
+      .fill(iiCanisterId);
 
     // If also requesting attributes, fill them in the textarea
     if (attributes !== undefined) {
@@ -106,6 +132,11 @@ export const authorizeWithUrl = async (
   // Wait for II window to close.
   // During the identity upgrade flow there is a delay of 5s
   await authPage.waitForEvent("close", { timeout: 15_000 });
+
+  // The window closing is not the app being finished: over the session protocol
+  // it has still to mint a delegation, and it keeps `#principal` hidden until it
+  // has one.
+  await expect(page.locator("#principal")).toBeVisible({ timeout: 15_000 });
 
   // Assert that the user is authenticated (valid principal)
   const principal = (await page.locator("#principal").textContent()) ?? "";

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -68,7 +68,18 @@ export default defineConfig(({ command, mode }): UserConfig => {
             {
               // `denied-app.com` is a second test-app origin used as an unlisted
               // (denied) dapp in the per-app gating e2e test.
-              hosts: ["nice-name.com", "denied-app.com"],
+              // `a.` and `b.` are siblings of one domain, with `auth.` as the
+              // derivation origin they share, so the session designs'
+              // cross-subdomain behaviour has somewhere to happen. All of them
+              // are the same canister, so one alternative-origins list serves
+              // every one of them.
+              hosts: [
+                "nice-name.com",
+                "a.nice-name.com",
+                "b.nice-name.com",
+                "auth.nice-name.com",
+                "denied-app.com",
+              ],
               canisterName: "test_app",
             },
             {
@@ -135,6 +146,9 @@ export default defineConfig(({ command, mode }): UserConfig => {
                 "https://identity.internetcomputer.org",
                 "https://identity.ic0.app",
                 "https://nice-name.com",
+                "https://a.nice-name.com",
+                "https://b.nice-name.com",
+                "https://auth.nice-name.com",
                 "https://denied-app.com",
                 "https://nice-issuer-custom-orig.com",
                 "https://be2us-64aaa-aaaaa-qaabq-cai.icp0.io",


### PR DESCRIPTION
Drives the scenarios from [`docs/ongoing/session-test-scenarios.md`](https://github.com/dfinity/internet-identity/pull/4282) in a real browser: 21 of the 36, in 24 tests — the ones a browser can reach without a second device or a wall-clock month.

The test app is what makes them observable. Its session panel reports the account an app's canisters see, the session key II resolves a session from, what the session and the app delegation have left, how many times the delegation has been replaced, and a log of what the client library did — so a scenario is a handful of assertions on that panel rather than a canister-call transcript. `.github/versions/test-app` therefore moves to `prerelease-2026-08-26-sessions-2`, a prerelease built from the client library's session branches. It is a prerelease deliberately: `/releases/latest` skips prereleases, so nothing else picks it up.

## What to read hardest

`fixtures/testApp.ts` — a page object for the app, so the specs say `signIn`, `replaceDelegation`, `ageDelegation` rather than naming elements. Sign-in waits for the panel to say "signed in": the provider's window closes before the app has minted and stored anything, so waiting on the window alone races the result.

`routes/authorize/app-sessions.spec.ts` — the scenarios, grouped the way the document groups them, each citing the requirement ids it covers.

## The rest of the diff

`vite.config.ts` and `utils.ts` add three hosts under `nice-name.com`, so the sibling-domain scenarios have siblings to share a session across. One canister serves every host the dev server maps there.

The existing authorize specs pick the legacy protocol explicitly. The test app's sign-in button now defaults to ICRC-25 and sessions, and a test that does not say which protocol it wants would silently change what it exercises.

## Coverage

Two tests carry no scenario id, because the document has no scenario for what they assert: that one identity is a different account at each app, and that a silent re-issue keeps the account or fails in one way. They cover requirements the document cites rather than scenarios it lists.

STAY-3 found a real defect while it was being written, in the signer transport rather than here: a channel reported itself open until the heartbeat noticed the window had gone two seconds later, so an immediate retry sent into the closed window and no new one opened. That is fixed in `@icp-sdk/signer` 5.6.3 ([icp-js-signer#53](https://github.com/dfinity/icp-js-signer/pull/53)), which the pinned prerelease builds against, so the test retries the way a user would — with no wait.

The 15 scenarios not here need a second device, a month of wall-clock, or a mainnet deploy.


## What is verified, and what is not

The 24 scenarios and the shared-fixture fix were run locally against this prerelease, and the specific failures the fixture fix addresses (`sso.spec.ts:93`, `index.spec.ts:267`, all of `legacy.spec.ts`) were confirmed one at a time. A full sequential `routes/authorize` sweep is still going as I open this; two `consent.spec.ts` failures in it are not yet explained, and I will follow them up here rather than hold the PR for them.
