### PR TITLE
fix(fe): handle null session delegation records

### DIFF
--- a/src/frontend/src/lib/stores/session-delegation.store.test.ts
+++ b/src/frontend/src/lib/stores/session-delegation.store.test.ts
@@ -135,6 +135,19 @@ describe("actorForIdentity — IDB resolution", () => {
     expect(result).toBeUndefined();
   });
 
+  it("returns undefined and purges when the stored record is null", async () => {
+    await idbSet(IDENTITY_NUMBER.toString(), null, TEST_STORE);
+
+    const { actorForIdentity } =
+      await import("$lib/stores/session-delegation.store");
+    const result = await actorForIdentity(IDENTITY_NUMBER);
+    expect(result).toBeUndefined();
+
+    await vi.runAllTimersAsync();
+    const remaining = await idbGet(IDENTITY_NUMBER.toString(), TEST_STORE);
+    expect(remaining).toBeUndefined();
+  });
+
   it("returns an actor when a valid unexpired record exists in IDB", async () => {
     const keyPair = await makeKeyPair();
     const chainJson = await makeChainJson();

--- a/src/frontend/src/lib/stores/session-delegation.store.ts
+++ b/src/frontend/src/lib/stores/session-delegation.store.ts
@@ -60,7 +60,7 @@ export const actorForIdentity = async (
     return authenticated.actor;
   }
 
-  let record: SessionDelegationRecord | undefined;
+  let record: SessionDelegationRecord | null | undefined;
   try {
     record = await idbGet<SessionDelegationRecord>(
       identityNumber.toString(),
@@ -71,6 +71,11 @@ export const actorForIdentity = async (
   }
 
   if (record === undefined) {
+    return undefined;
+  }
+
+  if (record === null) {
+    void purgeSession(identityNumber);
     return undefined;
   }
 


### PR DESCRIPTION
## Summary

- handle `null` records returned from the session-delegation IndexedDB store
- purge the invalid identity-specific record so authorization can recover
- add a regression test covering the reported failure

Fixes #4163

## Tests

- `npx vitest --config ./vitest.config.ts --run src/frontend/src/lib/stores/session-delegation.store.test.ts --exclude .claude/**`
- `npx eslint --max-warnings 0 src/frontend/src/lib/stores/session-delegation.store.ts src/frontend/src/lib/stores/session-delegation.store.test.ts`
- `npx prettier --check src/frontend/src/lib/stores/session-delegation.store.ts src/frontend/src/lib/stores/session-delegation.store.test.ts`
- `npx tsc --project ./tsconfig.all.json --noEmit`