### PR TITLE
fix(fe): handle invalid session delegation records

### DIFF
--- a/src/frontend/src/lib/stores/session-delegation.store.test.ts
+++ b/src/frontend/src/lib/stores/session-delegation.store.test.ts
@@ -135,6 +135,36 @@ describe("actorForIdentity — IDB resolution", () => {
     expect(result).toBeUndefined();
   });
 
+  it("returns undefined and purges when the stored record is null", async () => {
+    await idbSet(IDENTITY_NUMBER.toString(), null, TEST_STORE);
+
+    const { actorForIdentity } =
+      await import("$lib/stores/session-delegation.store");
+    const result = await actorForIdentity(IDENTITY_NUMBER);
+    expect(result).toBeUndefined();
+
+    await vi.runAllTimersAsync();
+    const remaining = await idbGet(IDENTITY_NUMBER.toString(), TEST_STORE);
+    expect(remaining).toBeUndefined();
+  });
+
+  it("returns undefined and purges when the stored record is malformed", async () => {
+    await idbSet(
+      IDENTITY_NUMBER.toString(),
+      { expiresAtMillis: FAR_FUTURE },
+      TEST_STORE,
+    );
+
+    const { actorForIdentity } =
+      await import("$lib/stores/session-delegation.store");
+    const result = await actorForIdentity(IDENTITY_NUMBER);
+    expect(result).toBeUndefined();
+
+    await vi.runAllTimersAsync();
+    const remaining = await idbGet(IDENTITY_NUMBER.toString(), TEST_STORE);
+    expect(remaining).toBeUndefined();
+  });
+
   it("returns an actor when a valid unexpired record exists in IDB", async () => {
     const keyPair = await makeKeyPair();
     const chainJson = await makeChainJson();

--- a/src/frontend/src/lib/stores/session-delegation.store.ts
+++ b/src/frontend/src/lib/stores/session-delegation.store.ts
@@ -5,6 +5,7 @@ import {
   del as idbDel,
 } from "idb-keyval";
 import { get } from "svelte/store";
+import { z } from "zod";
 import { Actor, ActorSubclass, HttpAgent } from "@icp-sdk/core/agent";
 import type { _SERVICE } from "$lib/generated/internet_identity_types";
 import { idlFactory as internet_identity_idl } from "$lib/generated/internet_identity_idl";
@@ -24,6 +25,17 @@ const SESSION_DELEGATION_STORE = createStore("ii-session-delegations", "keys");
 // + browser clock skew). Cleaner UX to fast-fail to a ceremony than to
 // surface an InvalidDelegation error mid-call.
 const EXPIRY_MARGIN_MS = 5 * 60 * 1000;
+
+const SessionDelegationRecordSchema: z.ZodType<SessionDelegationRecord> =
+  z.object({
+    identityNumber: z.bigint(),
+    keyPair: z.object({
+      privateKey: z.instanceof(CryptoKey),
+      publicKey: z.instanceof(CryptoKey),
+    }),
+    chainJson: z.string(),
+    expiresAtMillis: z.number(),
+  });
 
 export const mintSession = async ({
   identityNumber,
@@ -60,9 +72,9 @@ export const actorForIdentity = async (
     return authenticated.actor;
   }
 
-  let record: SessionDelegationRecord | undefined;
+  let storedRecord: unknown;
   try {
-    record = await idbGet<SessionDelegationRecord>(
+    storedRecord = await idbGet(
       identityNumber.toString(),
       SESSION_DELEGATION_STORE,
     );
@@ -70,9 +82,16 @@ export const actorForIdentity = async (
     return undefined;
   }
 
-  if (record === undefined) {
+  if (storedRecord === undefined) {
     return undefined;
   }
+
+  const parsedRecord = SessionDelegationRecordSchema.safeParse(storedRecord);
+  if (!parsedRecord.success) {
+    void purgeSession(identityNumber);
+    return undefined;
+  }
+  const record = parsedRecord.data;
 
   if (record.expiresAtMillis - EXPIRY_MARGIN_MS <= Date.now()) {
     void purgeSession(identityNumber);


### PR DESCRIPTION
## Summary

- validate session-delegation records loaded from IndexedDB with Zod
- treat `undefined` as a missing record and purge every other invalid stored value
- add regression tests covering `null` and malformed records

Fixes #4163

## Tests

- `npx vitest --config ./vitest.config.ts --run src/frontend/src/lib/stores/session-delegation.store.test.ts --exclude .claude/**`
- `npx eslint --max-warnings 0 src/frontend/src/lib/stores/session-delegation.store.ts src/frontend/src/lib/stores/session-delegation.store.test.ts`
- `npx prettier --check src/frontend/src/lib/stores/session-delegation.store.ts src/frontend/src/lib/stores/session-delegation.store.test.ts`
- `npx tsc --project ./tsconfig.all.json --noEmit`