### PR TITLE
feat(fe): legal links from the app metadata on the MCP connect screen

### DIFF
--- a/docs/ii-spec.mdx
+++ b/docs/ii-spec.mdx
@@ -368,12 +368,12 @@ Requirements:
 - `logo` must be a URL (relative URLs are resolved against the origin that served the document) pointing to a raster image _on that same origin_: the gateway domain that answered, when the document came from a fallback one. It must be served with one of the content types `image/png`, `image/jpeg`, `image/webp`, `image/gif` or `image/avif`, must not exceed 1 MiB, and must decode to an image of at most 4096 pixels per axis. Internet Identity downloads the logo (it is never hotlinked), so both the metadata document and the logo asset must be readable cross-origin (see the CORS note below).
 - The logo is not rendered as served: Internet Identity decodes it, draws it once into a canvas scaled to at most 512 pixels on its longest side, and renders that re-encoding from a `blob:` URL. What is displayed is therefore an image Internet Identity produced itself: still (an animated image is flattened to its first frame), bounded in size, and held in the browser's blob store rather than in the page's DOM or its JavaScript heap. `image/svg+xml` is not accepted, because a vector image cannot be put through that step across the browsers Internet Identity supports; applications with a vector logo serve a rasterized copy of it here.
 - Unlike the fields of the document, a logo that cannot be fetched, decoded, or does not meet the asset requirements above costs the application only its logo: fetching a second resource can fail transiently, and the name and description are still used.
-- `privacyPolicyUrl` and `termsOfServiceUrl` must be `https` URLs (relative URLs are resolved against the origin that served the document), on **any** origin. Unlike the logo, Internet Identity never fetches these documents; it renders a link the user opens themselves. So the same-origin requirement does not apply, and they may live on a separate domain from the application, as policies commonly do. Pinning the scheme is what still matters: it is what rules out `javascript:`, `data:` and anything else a link must never carry, along with plain `http`, which Internet Identity's production CSP (`connect-src 'self' https:`) means it would never have read the document over to begin with. An application served over `http` in local development therefore publishes neither field; publishing one that resolves to an `http` URL invalidates the whole document, like any other field that does not meet its requirements. Each link is shown only when the application publishes it.
+- `privacyPolicyUrl` and `termsOfServiceUrl` must be `https` URLs (relative URLs are resolved against the origin that served the document), on **any** origin. Unlike the logo, Internet Identity never fetches these documents; it renders a link the user opens themselves. So the same-origin requirement does not apply, and they may live on a separate domain from the application, as policies commonly do. Pinning the scheme is what still matters: it is what rules out `javascript:`, `data:` and anything else a link must never carry, along with plain `http`, which Internet Identity's production CSP (`connect-src 'self' https:`) means it would never have read the document over to begin with. An application served over `http` in local development therefore publishes neither field; publishing one that resolves to an `http` URL invalidates the whole document, like any other field that does not meet its requirements. Neither field may carry userinfo (a username or password): that grants an application no destination it could not write plainly, but it is the one way a value could read as one host while resolving to another, and the link text the user sees is Internet Identity's own. Surrounding whitespace is ignored, and a value that consists of nothing else is treated as invalid rather than as the origin's root. Each link is shown only when the application publishes it.
 - The metadata document must not exceed 8 KiB, must be answered with a `200` HTTP status code and must not redirect (Internet Identity _will not_ follow redirects for either the document or the logo).
 
 ### JSON Schema {#app-metadata-schema}
 
-The schema below expresses the requirements above, with two exceptions it cannot state: that bidirectional isolates must be balanced, and that a policy URL must resolve to an `https` URL (it may be written relative to the document, so the scheme is not part of the value). Whitespace normalization happens after validation and is not part of it either. Validating in CI is the easiest way to catch a mistake before it costs the application its metadata.
+The schema below expresses the requirements above, with two exceptions it cannot state: that bidirectional isolates must be balanced, and that a policy URL must resolve to an `https` URL carrying no userinfo (it may be written relative to the document, so neither is part of the value). Whitespace normalization happens after validation and is not part of it either. Validating in CI is the easiest way to catch a mistake before it costs the application its metadata.
 
 ```json
 {
@@ -407,12 +407,14 @@ The schema below expresses the requirements above, with two exceptions it cannot
       "description": "https URL of the application's privacy policy, on any origin",
       "type": "string",
       "minLength": 1,
+      "pattern": "\\S",
       "format": "uri-reference"
     },
     "termsOfServiceUrl": {
       "description": "https URL of the application's terms of service, on any origin",
       "type": "string",
       "minLength": 1,
+      "pattern": "\\S",
       "format": "uri-reference"
     }
   }

--- a/docs/ii-spec.mdx
+++ b/docs/ii-spec.mdx
@@ -337,13 +337,15 @@ In order to allow Internet Identity to read the path `/.well-known/ii-alternativ
 
 ## App metadata
 
-Internet Identity displays the name and logo of the client application on its authorization screens (e.g. "Continue to _App_"). Any application can provide this metadata itself (permissionlessly, without being included in any curated list) by serving a JSON document at the path `/.well-known/ii-app-metadata` (on the origin identified below):
+Internet Identity displays the name and logo of the client application on its authorization screens (e.g. "Continue to _App_"), and links to the application's privacy policy and terms of service on the MCP connect screen. Any application can provide this metadata itself (permissionlessly, without being included in any curated list) by serving a JSON document at the path `/.well-known/ii-app-metadata` (on the origin identified below):
 
 ```json
 {
   "name": "Example App",
   "description": "A short tagline shown on the sign-in screen",
-  "logo": "/logo.png"
+  "logo": "/logo.png",
+  "privacyPolicyUrl": "/privacy",
+  "termsOfServiceUrl": "https://legal.example.com/terms"
 }
 ```
 
@@ -366,11 +368,12 @@ Requirements:
 - `logo` must be a URL (relative URLs are resolved against the origin that served the document) pointing to a raster image _on that same origin_: the gateway domain that answered, when the document came from a fallback one. It must be served with one of the content types `image/png`, `image/jpeg`, `image/webp`, `image/gif` or `image/avif`, must not exceed 1 MiB, and must decode to an image of at most 4096 pixels per axis. Internet Identity downloads the logo (it is never hotlinked), so both the metadata document and the logo asset must be readable cross-origin (see the CORS note below).
 - The logo is not rendered as served: Internet Identity decodes it, draws it once into a canvas scaled to at most 512 pixels on its longest side, and renders that re-encoding from a `blob:` URL. What is displayed is therefore an image Internet Identity produced itself: still (an animated image is flattened to its first frame), bounded in size, and held in the browser's blob store rather than in the page's DOM or its JavaScript heap. `image/svg+xml` is not accepted, because a vector image cannot be put through that step across the browsers Internet Identity supports; applications with a vector logo serve a rasterized copy of it here.
 - Unlike the fields of the document, a logo that cannot be fetched, decoded, or does not meet the asset requirements above costs the application only its logo: fetching a second resource can fail transiently, and the name and description are still used.
+- `privacyPolicyUrl` and `termsOfServiceUrl` must be URLs (relative URLs are resolved against the origin that served the document) served over `https`, on **any** origin. Unlike the logo, Internet Identity never fetches these documents; it renders a link the user opens themselves. So the same-origin requirement does not apply, and they may live on a separate domain from the application, as policies commonly do. Pinning the scheme is what still matters: it is what rules out `javascript:`, `data:` and anything else a link must never carry. A plain-`http` URL is accepted only on the origin that served the document, so an application served over `http` in local development does not have to publish `https` links. Each link is shown only when the application publishes it.
 - The metadata document must not exceed 8 KiB, must be answered with a `200` HTTP status code and must not redirect (Internet Identity _will not_ follow redirects for either the document or the logo).
 
 ### JSON Schema {#app-metadata-schema}
 
-The schema below expresses the requirements above, with one exception it cannot state: that bidirectional isolates must be balanced. Whitespace normalization happens after validation and is not part of it either. Validating in CI is the easiest way to catch a mistake before it costs the application its metadata.
+The schema below expresses the requirements above, with two exceptions it cannot state: that bidirectional isolates must be balanced, and that a policy URL must be `https` unless it is on the document's own origin. Whitespace normalization happens after validation and is not part of it either. Validating in CI is the easiest way to catch a mistake before it costs the application its metadata.
 
 ```json
 {
@@ -399,6 +402,18 @@ The schema below expresses the requirements above, with one exception it cannot 
       "description": "URL of the raster application logo, on the same origin as this document",
       "type": "string",
       "minLength": 1
+    },
+    "privacyPolicyUrl": {
+      "description": "URL of the application's privacy policy, on any origin",
+      "type": "string",
+      "minLength": 1,
+      "format": "uri-reference"
+    },
+    "termsOfServiceUrl": {
+      "description": "URL of the application's terms of service, on any origin",
+      "type": "string",
+      "minLength": 1,
+      "format": "uri-reference"
     }
   }
 }

--- a/docs/ii-spec.mdx
+++ b/docs/ii-spec.mdx
@@ -368,12 +368,12 @@ Requirements:
 - `logo` must be a URL (relative URLs are resolved against the origin that served the document) pointing to a raster image _on that same origin_: the gateway domain that answered, when the document came from a fallback one. It must be served with one of the content types `image/png`, `image/jpeg`, `image/webp`, `image/gif` or `image/avif`, must not exceed 1 MiB, and must decode to an image of at most 4096 pixels per axis. Internet Identity downloads the logo (it is never hotlinked), so both the metadata document and the logo asset must be readable cross-origin (see the CORS note below).
 - The logo is not rendered as served: Internet Identity decodes it, draws it once into a canvas scaled to at most 512 pixels on its longest side, and renders that re-encoding from a `blob:` URL. What is displayed is therefore an image Internet Identity produced itself: still (an animated image is flattened to its first frame), bounded in size, and held in the browser's blob store rather than in the page's DOM or its JavaScript heap. `image/svg+xml` is not accepted, because a vector image cannot be put through that step across the browsers Internet Identity supports; applications with a vector logo serve a rasterized copy of it here.
 - Unlike the fields of the document, a logo that cannot be fetched, decoded, or does not meet the asset requirements above costs the application only its logo: fetching a second resource can fail transiently, and the name and description are still used.
-- `privacyPolicyUrl` and `termsOfServiceUrl` must be URLs (relative URLs are resolved against the origin that served the document) served over `https`, on **any** origin. Unlike the logo, Internet Identity never fetches these documents; it renders a link the user opens themselves. So the same-origin requirement does not apply, and they may live on a separate domain from the application, as policies commonly do. Pinning the scheme is what still matters: it is what rules out `javascript:`, `data:` and anything else a link must never carry. A plain-`http` URL is accepted only on the origin that served the document, so an application served over `http` in local development does not have to publish `https` links. Each link is shown only when the application publishes it.
+- `privacyPolicyUrl` and `termsOfServiceUrl` must be `https` URLs (relative URLs are resolved against the origin that served the document), on **any** origin. Unlike the logo, Internet Identity never fetches these documents; it renders a link the user opens themselves. So the same-origin requirement does not apply, and they may live on a separate domain from the application, as policies commonly do. Pinning the scheme is what still matters: it is what rules out `javascript:`, `data:` and anything else a link must never carry, along with plain `http`, which Internet Identity's production CSP (`connect-src 'self' https:`) means it would never have read the document over to begin with. An application served over `http` in local development therefore publishes neither field; publishing one that resolves to an `http` URL invalidates the whole document, like any other field that does not meet its requirements. Each link is shown only when the application publishes it.
 - The metadata document must not exceed 8 KiB, must be answered with a `200` HTTP status code and must not redirect (Internet Identity _will not_ follow redirects for either the document or the logo).
 
 ### JSON Schema {#app-metadata-schema}
 
-The schema below expresses the requirements above, with two exceptions it cannot state: that bidirectional isolates must be balanced, and that a policy URL must be `https` unless it is on the document's own origin. Whitespace normalization happens after validation and is not part of it either. Validating in CI is the easiest way to catch a mistake before it costs the application its metadata.
+The schema below expresses the requirements above, with two exceptions it cannot state: that bidirectional isolates must be balanced, and that a policy URL must resolve to an `https` URL (it may be written relative to the document, so the scheme is not part of the value). Whitespace normalization happens after validation and is not part of it either. Validating in CI is the easiest way to catch a mistake before it costs the application its metadata.
 
 ```json
 {
@@ -404,13 +404,13 @@ The schema below expresses the requirements above, with two exceptions it cannot
       "minLength": 1
     },
     "privacyPolicyUrl": {
-      "description": "URL of the application's privacy policy, on any origin",
+      "description": "https URL of the application's privacy policy, on any origin",
       "type": "string",
       "minLength": 1,
       "format": "uri-reference"
     },
     "termsOfServiceUrl": {
-      "description": "URL of the application's terms of service, on any origin",
+      "description": "https URL of the application's terms of service, on any origin",
       "type": "string",
       "minLength": 1,
       "format": "uri-reference"

--- a/src/frontend/src/lib/stores/app-metadata.store.ts
+++ b/src/frontend/src/lib/stores/app-metadata.store.ts
@@ -1,6 +1,7 @@
 /**
- * Per-origin display metadata (name, description, logo) for apps that sign in
- * with Internet Identity, e.g. shown on the authorize flow screens.
+ * Per-origin display metadata for apps that sign in with Internet Identity:
+ * the name, description and logo shown on the authorize flow screens, and the
+ * privacy policy and terms of service linked from the MCP connect screen.
  *
  * The metadata is sourced permissionlessly from the app itself, which serves a
  * `/.well-known/ii-app-metadata` file (see {@link fetchAppMetadata}) on the

--- a/src/frontend/src/lib/utils/appMetadata.test.ts
+++ b/src/frontend/src/lib/utils/appMetadata.test.ts
@@ -650,15 +650,20 @@ test("should keep a document carrying nothing but a policy url", async () => {
   });
 });
 
-test("should reject the whole document when a policy url is not https", async () => {
+test("should reject the whole document when a policy url is unusable", async () => {
   for (const url of [
     "http://legal.example.org/privacy", // plain http on another origin
     "http://app.example.com/privacy", // and on the app's own origin
     "javascript:alert(1)",
     "data:text/html,<h1>privacy</h1>",
     "mailto:privacy@example.com",
+    // Userinfo: reads as one host, resolves to another.
+    "https://trusted.example@evil.example/privacy",
+    "https://user:pass@evil.example/privacy",
     "https://", // unparseable
-    "",
+    "", // nothing at all, and nothing but whitespace
+    "   ",
+    "\t\n",
   ]) {
     setupFetchMock(
       Response.json({ name: "Example App", privacyPolicyUrl: url }),
@@ -666,6 +671,16 @@ test("should reject the whole document when a policy url is not https", async ()
 
     expect(await fetchAppMetadata(ORIGIN), url).toBeUndefined();
   }
+});
+
+test("should ignore whitespace around a policy url", async () => {
+  setupFetchMock(
+    Response.json({ privacyPolicyUrl: "  https://example.org/privacy\n" }),
+  );
+
+  expect(await fetchAppMetadata(ORIGIN)).toEqual({
+    privacyPolicyUrl: "https://example.org/privacy",
+  });
 });
 
 test("should ignore unknown fields", async () => {

--- a/src/frontend/src/lib/utils/appMetadata.test.ts
+++ b/src/frontend/src/lib/utils/appMetadata.test.ts
@@ -653,6 +653,7 @@ test("should keep a document carrying nothing but a policy url", async () => {
 test("should reject the whole document when a policy url is not https", async () => {
   for (const url of [
     "http://legal.example.org/privacy", // plain http on another origin
+    "http://app.example.com/privacy", // and on the app's own origin
     "javascript:alert(1)",
     "data:text/html,<h1>privacy</h1>",
     "mailto:privacy@example.com",
@@ -665,21 +666,6 @@ test("should reject the whole document when a policy url is not https", async ()
 
     expect(await fetchAppMetadata(ORIGIN), url).toBeUndefined();
   }
-});
-
-test("should accept http policy urls on the app's own origin (local development)", async () => {
-  setupFetchMock(
-    Response.json({ privacyPolicyUrl: "/privacy" }),
-    Response.json({ privacyPolicyUrl: "http://localhost:5173/privacy" }),
-  );
-
-  const relative = await fetchAppMetadata("http://localhost:5173");
-  const absolute = await fetchAppMetadata("http://localhost:5173");
-
-  expect(relative).toEqual({
-    privacyPolicyUrl: "http://localhost:5173/privacy",
-  });
-  expect(absolute).toEqual(relative);
 });
 
 test("should ignore unknown fields", async () => {

--- a/src/frontend/src/lib/utils/appMetadata.test.ts
+++ b/src/frontend/src/lib/utils/appMetadata.test.ts
@@ -612,6 +612,76 @@ test("should drop logos responding with a redirect", async () => {
   expect(await fetchAppMetadata(ORIGIN)).toEqual({ name: "Example App" });
 });
 
+test("should accept policy urls on any origin, unlike the logo", async () => {
+  const fetchMock = setupFetchMock(
+    Response.json({
+      name: "Example App",
+      privacyPolicyUrl: "https://legal.example.org/privacy",
+      termsOfServiceUrl: "https://legal.example.org/terms",
+    }),
+  );
+
+  // The documents are linked, never fetched, so they may live on whichever
+  // origin the app publishes them from — and nothing is requested for them.
+  expect(await fetchAppMetadata(ORIGIN)).toEqual({
+    name: "Example App",
+    privacyPolicyUrl: "https://legal.example.org/privacy",
+    termsOfServiceUrl: "https://legal.example.org/terms",
+  });
+  expect(fetchMock).toHaveBeenCalledTimes(1);
+});
+
+test("should resolve relative policy urls against the app origin", async () => {
+  setupFetchMock(
+    Response.json({ privacyPolicyUrl: "/privacy", termsOfServiceUrl: "terms" }),
+  );
+
+  expect(await fetchAppMetadata(ORIGIN)).toEqual({
+    privacyPolicyUrl: `${ORIGIN}/privacy`,
+    termsOfServiceUrl: `${ORIGIN}/terms`,
+  });
+});
+
+test("should keep a document carrying nothing but a policy url", async () => {
+  setupFetchMock(Response.json({ privacyPolicyUrl: "/privacy" }));
+
+  expect(await fetchAppMetadata(ORIGIN)).toEqual({
+    privacyPolicyUrl: `${ORIGIN}/privacy`,
+  });
+});
+
+test("should reject the whole document when a policy url is not https", async () => {
+  for (const url of [
+    "http://legal.example.org/privacy", // plain http on another origin
+    "javascript:alert(1)",
+    "data:text/html,<h1>privacy</h1>",
+    "mailto:privacy@example.com",
+    "https://", // unparseable
+    "",
+  ]) {
+    setupFetchMock(
+      Response.json({ name: "Example App", privacyPolicyUrl: url }),
+    );
+
+    expect(await fetchAppMetadata(ORIGIN), url).toBeUndefined();
+  }
+});
+
+test("should accept http policy urls on the app's own origin (local development)", async () => {
+  setupFetchMock(
+    Response.json({ privacyPolicyUrl: "/privacy" }),
+    Response.json({ privacyPolicyUrl: "http://localhost:5173/privacy" }),
+  );
+
+  const relative = await fetchAppMetadata("http://localhost:5173");
+  const absolute = await fetchAppMetadata("http://localhost:5173");
+
+  expect(relative).toEqual({
+    privacyPolicyUrl: "http://localhost:5173/privacy",
+  });
+  expect(absolute).toEqual(relative);
+});
+
 test("should ignore unknown fields", async () => {
   setupFetchMock(
     Response.json({ name: "Example App", futureField: { nested: true } }),

--- a/src/frontend/src/lib/utils/appMetadata.ts
+++ b/src/frontend/src/lib/utils/appMetadata.ts
@@ -2,14 +2,17 @@
  * Permissionless app metadata.
  *
  * Apps that integrate Internet Identity sign-in can provide their own display
- * name, description and logo for the authorize flow by serving a JSON file at
- * `/.well-known/ii-app-metadata` on their origin:
+ * name, description and logo for the authorize flow, and links to their privacy
+ * policy and terms of service for the MCP connect screen, by serving a JSON
+ * file at `/.well-known/ii-app-metadata` on their origin:
  *
  * ```json
  * {
  *   "name": "Example App",
  *   "description": "A short tagline shown on the sign-in screen",
- *   "logo": "/logo.png"
+ *   "logo": "/logo.png",
+ *   "privacyPolicyUrl": "/privacy",
+ *   "termsOfServiceUrl": "/terms"
  * }
  * ```
  *
@@ -40,6 +43,11 @@
  *   app's file is never hotlinked, nothing about it has to be trusted to be an
  *   image, and no attacker-controlled payload ends up in the DOM or the JS
  *   heap (which a `data:` URL would put in both).
+ * - The policy URLs are only ever linked to, never fetched, so they may point
+ *   at any origin — a policy commonly lives on a separate domain from the app
+ *   itself. They must be `https` (or on the app's own origin, so an app served
+ *   over plain `http` in local development still works), which is what rules
+ *   out `javascript:`, `data:` and the other schemes a link must never carry.
  * - Every failure mode (missing file, CORS, timeout, invalid JSON, …) yields
  *   `undefined` rather than an error: metadata is a display nicety and must
  *   never break the sign-in flow.
@@ -54,6 +62,10 @@ export interface AppMetadata {
   description?: string;
   /** Ready-to-render `<img src>` value (a `blob:` URL for fetched logos). */
   logo?: string;
+  /** Absolute URL of the app's privacy policy, for the user to open. */
+  privacyPolicyUrl?: string;
+  /** Absolute URL of the app's terms of service, for the user to open. */
+  termsOfServiceUrl?: string;
 }
 
 /**
@@ -373,6 +385,48 @@ const validateLogoUrl = (value: unknown, origin: string): Validated<URL> => {
 };
 
 /**
+ * Validate a `privacyPolicyUrl`/`termsOfServiceUrl` field: it must resolve
+ * (relative to the app origin) to an `https` URL, on any origin.
+ *
+ * Unlike the logo, II never fetches these documents — it renders a link the
+ * user opens in a new tab — so the same-origin rule that keeps the sign-in
+ * private from third parties does not apply, and requiring it would only lock
+ * out the many apps whose policies live on a separate domain. Pinning the
+ * scheme is what still matters: it rules out `javascript:`, `data:` and
+ * anything else a link must never carry. A plain-`http` URL is accepted on the
+ * document's own origin alone, so an app served over `http` in local
+ * development is not forced to publish `https` links.
+ */
+const validatePolicyUrl = (
+  value: unknown,
+  field: string,
+  origin: string,
+): Validated<string> => {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value !== "string" || value.length === 0) {
+    return reject(field, "must be a non-empty string");
+  }
+  let url: URL;
+  try {
+    url = new URL(value, origin);
+  } catch {
+    return reject(field, "must be a valid URL");
+  }
+  if (
+    url.protocol !== "https:" &&
+    !(url.protocol === "http:" && url.origin === new URL(origin).origin)
+  ) {
+    return reject(
+      field,
+      "must be an https URL, or a URL on the same origin as the document",
+    );
+  }
+  return url.href;
+};
+
+/**
  * Re-encode the downloaded bytes as an image II has produced itself, and hand
  * back a `blob:` URL for it.
  *
@@ -535,7 +589,8 @@ const fetchAppMetadataFrom = async (
     ) {
       return { served: true, metadata: undefined };
     }
-    const { name, description, logo } = parsed as Record<string, unknown>;
+    const { name, description, logo, privacyPolicyUrl, termsOfServiceUrl } =
+      parsed as Record<string, unknown>;
     // Validate every field before bailing out, so a document with more than
     // one problem reports all of them in one go.
     const validName = validateTextField(name, "name", MAX_APP_NAME_LENGTH);
@@ -545,16 +600,30 @@ const fetchAppMetadataFrom = async (
       MAX_APP_DESCRIPTION_LENGTH,
     );
     const logoUrl = validateLogoUrl(logo, origin);
+    const validPrivacyPolicyUrl = validatePolicyUrl(
+      privacyPolicyUrl,
+      "privacyPolicyUrl",
+      origin,
+    );
+    const validTermsOfServiceUrl = validatePolicyUrl(
+      termsOfServiceUrl,
+      "termsOfServiceUrl",
+      origin,
+    );
     if (
       validName === INVALID ||
       validDescription === INVALID ||
-      logoUrl === INVALID
+      logoUrl === INVALID ||
+      validPrivacyPolicyUrl === INVALID ||
+      validTermsOfServiceUrl === INVALID
     ) {
       return { served: true, metadata: undefined };
     }
     const metadata: AppMetadata = {
       name: validName,
       description: validDescription,
+      privacyPolicyUrl: validPrivacyPolicyUrl,
+      termsOfServiceUrl: validTermsOfServiceUrl,
     };
     if (logoUrl !== undefined) {
       // The asset is a second network resource, so unlike the fields of the
@@ -571,7 +640,9 @@ const fetchAppMetadataFrom = async (
     if (
       metadata.name === undefined &&
       metadata.description === undefined &&
-      metadata.logo === undefined
+      metadata.logo === undefined &&
+      metadata.privacyPolicyUrl === undefined &&
+      metadata.termsOfServiceUrl === undefined
     ) {
       return { served: true, metadata: undefined };
     }

--- a/src/frontend/src/lib/utils/appMetadata.ts
+++ b/src/frontend/src/lib/utils/appMetadata.ts
@@ -45,9 +45,8 @@
  *   heap (which a `data:` URL would put in both).
  * - The policy URLs are only ever linked to, never fetched, so they may point
  *   at any origin — a policy commonly lives on a separate domain from the app
- *   itself. They must be `https` (or on the app's own origin, so an app served
- *   over plain `http` in local development still works), which is what rules
- *   out `javascript:`, `data:` and the other schemes a link must never carry.
+ *   itself. They must be `https`, which is what rules out `javascript:`,
+ *   `data:` and the other schemes a link must never carry.
  * - Every failure mode (missing file, CORS, timeout, invalid JSON, …) yields
  *   `undefined` rather than an error: metadata is a display nicety and must
  *   never break the sign-in flow.
@@ -393,9 +392,9 @@ const validateLogoUrl = (value: unknown, origin: string): Validated<URL> => {
  * private from third parties does not apply, and requiring it would only lock
  * out the many apps whose policies live on a separate domain. Pinning the
  * scheme is what still matters: it rules out `javascript:`, `data:` and
- * anything else a link must never carry. A plain-`http` URL is accepted on the
- * document's own origin alone, so an app served over `http` in local
- * development is not forced to publish `https` links.
+ * anything else a link must never carry, and `http`, which II's production CSP
+ * (`connect-src 'self' https:`) means it would never have read this document
+ * over in the first place.
  */
 const validatePolicyUrl = (
   value: unknown,
@@ -414,14 +413,8 @@ const validatePolicyUrl = (
   } catch {
     return reject(field, "must be a valid URL");
   }
-  if (
-    url.protocol !== "https:" &&
-    !(url.protocol === "http:" && url.origin === new URL(origin).origin)
-  ) {
-    return reject(
-      field,
-      "must be an https URL, or a URL on the same origin as the document",
-    );
+  if (url.protocol !== "https:") {
+    return reject(field, "must be an https URL");
   }
   return url.href;
 };

--- a/src/frontend/src/lib/utils/appMetadata.ts
+++ b/src/frontend/src/lib/utils/appMetadata.ts
@@ -395,6 +395,13 @@ const validateLogoUrl = (value: unknown, origin: string): Validated<URL> => {
  * anything else a link must never carry, and `http`, which II's production CSP
  * (`connect-src 'self' https:`) means it would never have read this document
  * over in the first place.
+ *
+ * Userinfo is refused as well. It grants an app no destination it couldn't
+ * write plainly — any https origin is allowed by design — but it is the one way
+ * a value could read as one host while resolving to another
+ * (`https://trusted.example@evil.example/privacy`), and the link text the user
+ * sees is II's own generic "Privacy Policy", so the URL itself is all a
+ * careful user has to go on.
  */
 const validatePolicyUrl = (
   value: unknown,
@@ -404,17 +411,27 @@ const validatePolicyUrl = (
   if (value === undefined) {
     return undefined;
   }
-  if (typeof value !== "string" || value.length === 0) {
-    return reject(field, "must be a non-empty string");
+  if (typeof value !== "string") {
+    return reject(field, "must be a string");
+  }
+  // The URL parser ignores surrounding whitespace, so a value with nothing else
+  // in it would resolve to the origin's root rather than being refused. Same
+  // rule as the text fields: a value that reads as absent is absent.
+  const trimmed = value.trim();
+  if (trimmed.length === 0) {
+    return reject(field, "must contain at least one non-whitespace character");
   }
   let url: URL;
   try {
-    url = new URL(value, origin);
+    url = new URL(trimmed, origin);
   } catch {
     return reject(field, "must be a valid URL");
   }
   if (url.protocol !== "https:") {
     return reject(field, "must be an https URL");
+  }
+  if (url.username !== "" || url.password !== "") {
+    return reject(field, "must not carry a username or password");
   }
   return url.href;
 };

--- a/src/frontend/src/routes/(new-styling)/mcp/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/mcp/+page.svelte
@@ -373,6 +373,7 @@
 {:else if phase.kind === "authorize" && mcpServer !== undefined && $lastUsedIdentitiesStore.selected !== undefined}
   <McpAuthorizeView
     mcpServerHost={mcpServer.host}
+    mcpServerOrigin={mcpServer.origin}
     requestedTtlSeconds={params.kind === "valid" ? params.ttlSeconds : 3600}
     onAuthorize={handleAuthorize}
   />

--- a/src/frontend/src/routes/(new-styling)/mcp/views/McpAuthorizeView.svelte
+++ b/src/frontend/src/routes/(new-styling)/mcp/views/McpAuthorizeView.svelte
@@ -13,7 +13,7 @@
   import AccessLevelSelector from "$lib/components/ui/AccessLevelSelector.svelte";
   import type { AccessLevel } from "$lib/utils/accessLevel";
   import { accessLevelStore } from "$lib/stores/access-level.store";
-  import { ChevronDownIcon, InfoIcon } from "@lucide/svelte";
+  import { ChevronDownIcon } from "@lucide/svelte";
   import { Trans } from "$lib/components/locale";
   import { t } from "$lib/stores/locale.store";
   import { AuthLastUsedFlow } from "$lib/flows/authLastUsedFlow.svelte";
@@ -21,10 +21,14 @@
   import { lastUsedIdentitiesStore } from "$lib/stores/last-used-identities.store";
   import { sessionStore } from "$lib/stores/session.store";
   import { handleError } from "$lib/components/utils/error";
+  import { getAppMetadataStore } from "$lib/stores/app-metadata.store";
 
   interface Props {
     /** Hostname of the MCP server (display, e.g. mcp.id.ai). */
     mcpServerHost: string;
+    /** Origin of the MCP server, which is where it publishes the metadata this
+     *  screen links to (its privacy policy and terms of service). */
+    mcpServerOrigin: string;
     /** Session duration the request asked for (seconds, already clamped to
      *  [10 min, 30 days]); the initial selection, which the user can change. */
     requestedTtlSeconds: number;
@@ -34,7 +38,23 @@
     onAuthorize: (ttlSeconds: number, accessLevel: AccessLevel) => void;
   }
 
-  const { mcpServerHost, requestedTtlSeconds, onAuthorize }: Props = $props();
+  const {
+    mcpServerHost,
+    mcpServerOrigin,
+    requestedTtlSeconds,
+    onAuthorize,
+  }: Props = $props();
+
+  // The legal documents the server publishes for itself, in the same
+  // permissionless well-known document apps use for their sign-in presentation.
+  // The metadata is exactly as trustworthy as the origin serving it, so the
+  // name is only ever used to say whose documents these are — next to the host
+  // the screen has verified and displays above.
+  const metadataStore = $derived(getAppMetadataStore(mcpServerOrigin));
+  const metadata = $derived($metadataStore);
+  const privacyPolicyUrl = $derived(metadata.privacyPolicyUrl);
+  const termsOfServiceUrl = $derived(metadata.termsOfServiceUrl);
+  const serverDisplayName = $derived(metadata.name ?? mcpServerHost);
 
   // Connecting authorizes this agent for the user's identity — no account is
   // chosen here (accounts are app-specific; the MCP server is the connector, not
@@ -173,25 +193,58 @@
       class="mb-5"
     />
 
-    <!-- Fine print: the connection can be revoked from Settings at any time.
-         Opens in a new tab so the connect request in this one isn't lost. -->
+    <!-- Fine print: the server's own legal documents, shown only for the ones
+         it publishes. They open in a new tab so the connect request in this one
+         isn't lost. -->
     <div
       class="border-border-tertiary bg-bg-primary sm:bg-bg-secondary sticky bottom-0 z-1 -mb-3 border-t pt-4 pb-3"
     >
-      <div class="text-text-tertiary mb-4 flex items-start gap-2 text-sm">
-        <InfoIcon class="mt-0.5 size-4 shrink-0" />
-        <span>
-          <Trans>
-            Revoke access anytime in your <a
-              href="/manage/settings"
-              target="_blank"
-              rel="noopener noreferrer"
-              class="text-text-primary font-medium underline-offset-2 hover:underline"
-              >settings</a
-            >.
-          </Trans>
-        </span>
-      </div>
+      {#if privacyPolicyUrl !== undefined || termsOfServiceUrl !== undefined}
+        <div class="text-text-tertiary mb-4 text-sm text-pretty">
+          {#if privacyPolicyUrl !== undefined && termsOfServiceUrl !== undefined}
+            <Trans>
+              Review {serverDisplayName}'s
+              <a
+                href={privacyPolicyUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                class="text-text-primary font-medium underline-offset-2 hover:underline"
+                >Privacy Policy</a
+              >
+              and
+              <a
+                href={termsOfServiceUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                class="text-text-primary font-medium underline-offset-2 hover:underline"
+                >Terms of Service</a
+              >.
+            </Trans>
+          {:else if privacyPolicyUrl !== undefined}
+            <Trans>
+              Review {serverDisplayName}'s
+              <a
+                href={privacyPolicyUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                class="text-text-primary font-medium underline-offset-2 hover:underline"
+                >Privacy Policy</a
+              >.
+            </Trans>
+          {:else}
+            <Trans>
+              Review {serverDisplayName}'s
+              <a
+                href={termsOfServiceUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                class="text-text-primary font-medium underline-offset-2 hover:underline"
+                >Terms of Service</a
+              >.
+            </Trans>
+          {/if}
+        </div>
+      {/if}
       <button
         class="btn btn-primary btn-xl w-full"
         onclick={handleAllowAccess}

--- a/src/frontend/tests/e2e-playwright/fixtures/mcp.ts
+++ b/src/frontend/tests/e2e-playwright/fixtures/mcp.ts
@@ -15,6 +15,7 @@ import type {
 } from "$lib/generated/internet_identity_types";
 import { toBase64URL } from "../../../src/lib/utils/utils";
 import { AUTH_CALLBACKS_PATH } from "../../../src/lib/utils/authCallbacks";
+import { APP_METADATA_PATH } from "../../../src/lib/utils/appMetadata";
 import { holdToConfirm, II_URL } from "../utils";
 import { DEFAULT_HOST } from "./identity";
 
@@ -126,6 +127,17 @@ export type McpFixture = {
    * the delegation (i.e. before "Allow access").
    */
   installInterceptor: (page: Page) => Promise<void>;
+  /**
+   * Publishes `document` at this origin's `/.well-known/ii-app-metadata`, the
+   * permissionless document an app — here the MCP server — serves to provide
+   * its own display metadata and legal links. Call before navigating to
+   * `/mcp`; an origin that publishes nothing answers 404 (the connect
+   * interceptor's fallthrough), which is what the other tests exercise.
+   */
+  serveAppMetadata: (
+    page: Page,
+    document: Record<string, unknown>,
+  ) => Promise<void>;
   /** Builds the `/mcp` authorize URL with the request params in the fragment. */
   buildAuthorizeUrl: (opts: {
     app: string;
@@ -351,6 +363,22 @@ export const test = base.extend<{ mcp: McpFixture }>({
       });
     };
 
+    const serveAppMetadata = async (
+      page: Page,
+      document: Record<string, unknown>,
+    ): Promise<void> => {
+      // Read cross-origin by the II frontend, so it carries CORS headers and
+      // the application/json content type, like the allow-list above.
+      // Registered after the connect interceptor so this narrower route wins.
+      await page.route(`${MCP_SERVER_ORIGIN}${APP_METADATA_PATH}`, (route) =>
+        route.fulfill({
+          status: 200,
+          headers: { ...CORS_HEADERS, "content-type": "application/json" },
+          body: JSON.stringify(document),
+        }),
+      );
+    };
+
     const trustServer = async (page: Page): Promise<void> => {
       // The trusted server is the identity's synced (on-chain) config, set via
       // Settings — so seed it the way a user would. Mock this origin's RFC 9728
@@ -427,6 +455,7 @@ export const test = base.extend<{ mcp: McpFixture }>({
       enableFinishRedirect,
       trustServer,
       installInterceptor,
+      serveAppMetadata,
       buildAuthorizeUrl,
     });
   },

--- a/src/frontend/tests/e2e-playwright/fixtures/mcp.ts
+++ b/src/frontend/tests/e2e-playwright/fixtures/mcp.ts
@@ -131,8 +131,8 @@ export type McpFixture = {
    * Publishes `document` at this origin's `/.well-known/ii-app-metadata`, the
    * permissionless document an app — here the MCP server — serves to provide
    * its own display metadata and legal links. Call before navigating to
-   * `/mcp`; an origin that publishes nothing answers 404 (the connect
-   * interceptor's fallthrough), which is what the other tests exercise.
+   * `/mcp`. Without it the origin publishes nothing: the fixture answers the
+   * path 404, which is what every other test exercises.
    */
   serveAppMetadata: (
     page: Page,
@@ -204,8 +204,16 @@ const connectPageHtml = (redeemPath: string): string => `<!doctype html>
 </script>`;
 
 export const test = base.extend<{ mcp: McpFixture }>({
-  // eslint-disable-next-line no-empty-pattern -- playwright fixtures require the destructure
-  mcp: async ({}, use) => {
+  mcp: async ({ page }, use) => {
+    // The connect screen asks the server's origin for its app-metadata
+    // document as soon as it mounts, so every test that reaches `/mcp` makes
+    // that request, including the ones that never install the server stand-in.
+    // Answer it 404 here (an origin that publishes nothing) so no test reaches
+    // the real mcp.id.ai over the network. `serveAppMetadata` and the connect
+    // interceptor register later in the test body and take precedence.
+    await page.route(`${MCP_SERVER_ORIGIN}${APP_METADATA_PATH}`, (route) =>
+      route.fulfill({ status: 404, headers: CORS_HEADERS }),
+    );
     // The server's two per-session keys: X (registration key, public part rides
     // the link) and S (the long-lived session key it wants bound).
     const registrationIdentity = Ed25519KeyIdentity.generate();
@@ -369,7 +377,7 @@ export const test = base.extend<{ mcp: McpFixture }>({
     ): Promise<void> => {
       // Read cross-origin by the II frontend, so it carries CORS headers and
       // the application/json content type, like the allow-list above.
-      // Registered after the connect interceptor so this narrower route wins.
+      // Registered after the fixture's 404 default, so this answer wins.
       await page.route(`${MCP_SERVER_ORIGIN}${APP_METADATA_PATH}`, (route) =>
         route.fulfill({
           status: 200,

--- a/src/frontend/tests/e2e-playwright/routes/mcp.spec.ts
+++ b/src/frontend/tests/e2e-playwright/routes/mcp.spec.ts
@@ -102,15 +102,12 @@ test("The connect screen names the acting identity and keeps the consent in view
   await expect(identityRow).toContainText("Test User");
 
   const allowAccess = page.getByRole("button", { name: "Allow access" });
-  const revokeNote = page.getByRole("link", { name: "settings" });
   await expect(identityRow).toBeInViewport();
   await expect(allowAccess).toBeInViewport();
-  await expect(revokeNote).toBeInViewport();
 
   await page.mouse.wheel(0, 2000);
   await expect(identityRow).toBeInViewport();
   await expect(allowAccess).toBeInViewport();
-  await expect(revokeNote).toBeInViewport();
 
   // The screen carries the identity and its control, so it has no header.
   await expect(
@@ -124,6 +121,62 @@ test("The connect screen names the acting identity and keeps the consent in view
   await expect(
     page.getByRole("button", { name: "Add identity" }),
   ).toBeVisible();
+});
+
+test("The connect screen links the legal documents the server publishes", async ({
+  page,
+  mcp,
+}) => {
+  await mcp.serveAppMetadata(page, {
+    name: "ICP MCP",
+    privacyPolicyUrl: "/privacy",
+    termsOfServiceUrl: "https://legal.example.com/terms",
+  });
+  await addVirtualAuthenticator(page);
+  await page.goto(mcp.buildAuthorizeUrl({ app: APP }));
+  await signUp(page);
+
+  const privacyPolicy = page.getByRole("link", { name: "Privacy Policy" });
+  const termsOfService = page.getByRole("link", { name: "Terms of Service" });
+  // The name comes from the document too, so it says whose documents these
+  // are; the verified host stays in the heading above.
+  await expect(page.getByText("Review ICP MCP's")).toBeVisible();
+  await expect(privacyPolicy).toHaveAttribute(
+    "href",
+    `${mcp.mcpOrigin}/privacy`,
+  );
+  await expect(termsOfService).toHaveAttribute(
+    "href",
+    "https://legal.example.com/terms",
+  );
+  // Both open in a new tab, so the connect request in this one isn't lost.
+  await expect(privacyPolicy).toHaveAttribute("target", "_blank");
+  await expect(termsOfService).toHaveAttribute("target", "_blank");
+
+  // The fine print is pinned above the CTA, so it stays with it when the panel
+  // scrolls.
+  await page.mouse.wheel(0, 2000);
+  await expect(privacyPolicy).toBeInViewport();
+  await expect(
+    page.getByRole("button", { name: "Allow access" }),
+  ).toBeInViewport();
+});
+
+test("A server publishing no legal documents shows no fine print", async ({
+  page,
+  mcp,
+}) => {
+  await addVirtualAuthenticator(page);
+  await page.goto(mcp.buildAuthorizeUrl({ app: APP }));
+  await signUp(page);
+
+  await expect(
+    page.getByRole("button", { name: "Allow access" }),
+  ).toBeVisible();
+  await expect(page.getByRole("link", { name: "Privacy Policy" })).toBeHidden();
+  await expect(
+    page.getByRole("link", { name: "Terms of Service" }),
+  ).toBeHidden();
 });
 
 test("Signing up to an untrusted server prompts to add it in settings", async ({


### PR DESCRIPTION
# Motivation

The MCP connect screen ("Connect _mcp.example.com_") asks the user to hand an AI agent a standing delegation to their identity. What it says about the server it is connecting is the origin in its heading and nothing else: the server has no way to point the user at its privacy policy or its terms of service on the screen where the decision is actually made.

Apps already publish their own presentation permissionlessly, in the `/.well-known/ii-app-metadata` document introduced by #4221. This extends that document with the two legal links and renders them on the connect screen, which until now consumed no app metadata at all.

# Changes

- **Two new optional fields**, `privacyPolicyUrl` and `termsOfServiceUrl`, validated in `$lib/utils/appMetadata.ts` like the rest of the document: absent is fine, present-and-invalid rejects the whole document with a console warning naming the field, and a document carrying nothing but a policy URL is still usable.
- **They may point at any origin.** Unlike the logo, II never fetches these documents — it renders a link the user opens themselves — so the same-origin rule that keeps the sign-in private from third parties does not apply, and requiring it would only lock out the many apps whose policies live on a separate domain. What is pinned instead is the scheme: `https`, which rules out `javascript:`, `data:` and anything else a link must never carry, along with plain `http` — II's production CSP (`connect-src 'self' https:`) means it would never have read the document over `http` to begin with, and the only screen rendering these links takes its origin from `parseMcpServerUrl`, which is https-only. An app served over `http` in local development publishes neither field.
- **The fine print above "Allow access"** becomes the server's own legal links, replacing the "Revoke access anytime in your settings" note: `Review <name>'s Privacy Policy and Terms of Service.`, in three translatable variants so a server publishing one link reads correctly. A server that publishes neither gets no fine print, and the spacing goes with it. Both links open in a new tab, so the connect request in this one isn't lost.
- **The name comes from the same document**, falling back to the host when the server publishes none — it only ever says whose documents these are. The metadata is exactly as trustworthy as the origin serving it, which is why the verified host stays in the heading above, unchanged.
- **Spec**: `docs/ii-spec.mdx` documents the fields, the scheme rule and its local-development exception, and extends the published JSON Schema. The schema preamble now names two requirements it cannot express (isolate balance, and the policy-URL scheme) rather than one.

# Tests

- Unit tests in `appMetadata.test.ts` for any-origin acceptance (with nothing fetched for it), relative resolution against the origin that served the document, a policy-URL-only document, and the scheme rejections: `http` both cross-origin and on the app's own origin, `javascript:`, `data:`, `mailto:`, unparseable, and empty.
- E2E: the MCP fixture gains `serveAppMetadata`, and `mcp.spec.ts` covers the links rendering with the published hrefs and staying pinned above the CTA when the panel scrolls, plus a server publishing nothing showing no fine print. The "keeps the consent in view" spec no longer asserts on the revoke link this removes; that sticky-footer coverage moved to the new spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

