### PR TITLE
feat(fe): connect a local MCP server over loopback

### DIFF
--- a/src/frontend/src/lib/constants/store.constants.ts
+++ b/src/frontend/src/lib/constants/store.constants.ts
@@ -4,6 +4,7 @@ export const storeLocalStorageKey = {
   CliAccess: "ii-cli-access",
   LastSharedEmails: "ii-last-shared-emails",
   AccessLevel: "ii-access-level",
+  McpLocalServerNotice: "ii-mcp-local-server-notice",
 } as const;
 
 export type StoreLocalStorageKey =

--- a/src/frontend/src/lib/utils/authCallbacks.test.ts
+++ b/src/frontend/src/lib/utils/authCallbacks.test.ts
@@ -92,7 +92,7 @@ describe("matchDeclaredCallback", () => {
     const foreign = "https://evil.example.com/connect";
     stubFetch({ body: JSON.stringify({ callbacks: [foreign] }) });
     await expect(matchDeclaredCallback(ORIGIN, foreign)).rejects.toThrow(
-      /not on the server's origin/,
+      /not on the trusted server's origin/,
     );
   });
 

--- a/src/frontend/src/lib/utils/authCallbacks.ts
+++ b/src/frontend/src/lib/utils/authCallbacks.ts
@@ -153,23 +153,42 @@ export const matchDeclaredCallback = async (
       "The MCP server does not declare this callback in its allow-list.",
     );
   }
-  // Validate the matched entry itself — never just the fact of a match. The
-  // caller only asks about callbacks on the trusted origin, but re-verifying
-  // here keeps the invariant local: a declared cross-origin callback is
-  // rejected rather than honoured, whatever the caller did.
-  let matched: URL;
+  // Validate the matched entry itself — never just the fact of a match.
+  return assertDeliverableCallback(origin, requestedCallback);
+};
+
+/**
+ * The checks every callback must pass before anything is delivered to it,
+ * whatever established that it is the right one: it must parse, sit on the
+ * trust-confirmed `origin`, and carry no fragment of its own.
+ *
+ * Separate from the allow-list so both connect paths share it — a remote
+ * server's callback reaches this after matching its declared entry, a local
+ * server's (which has no allow-list to match) reaches it directly. Callers
+ * generally derive `origin` from the callback itself, so the same-origin check
+ * is usually a tautology; keeping it here means the invariant holds locally
+ * even if a caller ever stops doing that. The fragment check is not a
+ * tautology: the connect flow appends its own fragment, and a callback that
+ * already carried one would produce `...#theirs#delegation=...`, mangling the
+ * delivery. Nothing legitimate needs one.
+ *
+ * Returns the callback unchanged, so it reads as the value that passed.
+ */
+export const assertDeliverableCallback = (
+  origin: string,
+  callback: string,
+): string => {
+  let parsed: URL;
   try {
-    matched = new URL(requestedCallback);
+    parsed = new URL(callback);
   } catch {
-    throw new Error("The declared callback is not a valid URL.");
+    throw new Error("The callback is not a valid URL.");
   }
-  if (matched.origin !== origin) {
-    throw new Error("The declared callback is not on the server's origin.");
+  if (parsed.origin !== origin) {
+    throw new Error("The callback is not on the trusted server's origin.");
   }
-  if (matched.hash !== "") {
-    // The connect flow appends its own fragment; a declared fragment could
-    // clobber or be clobbered by it. Nothing legitimate needs one.
-    throw new Error("The declared callback must not carry a fragment.");
+  if (parsed.hash !== "") {
+    throw new Error("The callback must not carry a fragment.");
   }
-  return requestedCallback;
+  return callback;
 };

--- a/src/frontend/src/lib/utils/mcpServer.test.ts
+++ b/src/frontend/src/lib/utils/mcpServer.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { parseMcpServerUrl, probeMcpServer } from "./mcpServer";
+import {
+  isLoopbackUrl,
+  LOCAL_MCP_SERVER_URL,
+  parseMcpServerUrl,
+  probeMcpServer,
+  trustsOrigin,
+} from "./mcpServer";
 
 describe("parseMcpServerUrl", () => {
   it("accepts a bare https origin and normalizes its parts", () => {
@@ -7,6 +13,7 @@ describe("parseMcpServerUrl", () => {
       url: "https://mcp.id.ai",
       origin: "https://mcp.id.ai",
       host: "mcp.id.ai",
+      isLoopback: false,
     });
   });
 
@@ -17,6 +24,7 @@ describe("parseMcpServerUrl", () => {
       url: "https://mcp.id.ai/mcp?v=1",
       origin: "https://mcp.id.ai",
       host: "mcp.id.ai",
+      isLoopback: false,
     });
   });
 
@@ -25,6 +33,7 @@ describe("parseMcpServerUrl", () => {
       url: "https://mcp.id.ai:8443/mcp",
       origin: "https://mcp.id.ai:8443",
       host: "mcp.id.ai:8443",
+      isLoopback: false,
     });
   });
 
@@ -44,9 +53,47 @@ describe("parseMcpServerUrl", () => {
     expect(parseMcpServerUrl("http://mcp.id.ai/mcp")).toBeUndefined();
   });
 
-  it("rejects a plain-http loopback URL", () => {
-    // The gate is https-only, so an http loopback callback never parses.
-    expect(parseMcpServerUrl("http://127.0.0.1:8080/callback")).toBeUndefined();
+  it("accepts a plain-http loopback URL, port and path included", () => {
+    // A local server binds a fresh port per sign-in, so its callback carries
+    // one; the port-less stored form is what trust matching compares against.
+    expect(parseMcpServerUrl("http://127.0.0.1:8080/callback")).toEqual({
+      url: "http://127.0.0.1:8080/callback",
+      origin: "http://127.0.0.1:8080",
+      host: "127.0.0.1:8080",
+      isLoopback: true,
+    });
+  });
+
+  it("accepts the port-less local form that Settings stores", () => {
+    expect(parseMcpServerUrl(LOCAL_MCP_SERVER_URL)).toEqual({
+      url: "http://127.0.0.1",
+      origin: "http://127.0.0.1",
+      host: "127.0.0.1",
+      isLoopback: true,
+    });
+  });
+
+  it("rejects loopback lookalikes that aren't the IPv4 literal", () => {
+    // `localhost` is a name, `::1` can't be expressed in CSP's host-source
+    // grammar (so it would die at delivery), `0.0.0.0` isn't loopback, and a
+    // name that merely resolves to loopback is rebinding surface.
+    for (const raw of [
+      "http://localhost:8080/callback",
+      "http://[::1]:8080/callback",
+      "http://0.0.0.0:8080/callback",
+      "http://127.0.0.1.nip.io:8080/callback",
+      "http://127.0.0.1.evil.example.com/callback",
+    ]) {
+      expect(parseMcpServerUrl(raw)).toBeUndefined();
+    }
+  });
+
+  it("rejects an https loopback URL", () => {
+    // A local listener can't present a CA-trusted cert; http is the loopback
+    // shape, and accepting https here would only widen what matches.
+    expect(
+      parseMcpServerUrl("https://127.0.0.1:8080/callback")?.isLoopback,
+    ).toBe(false);
   });
 
   it("rejects non-http(s) schemes", () => {
@@ -82,6 +129,61 @@ describe("parseMcpServerUrl", () => {
     expect(parsed?.origin).toBe("https://evil.example.com");
     expect(parsed?.host).toBe("evil.example.com");
     expect(parsed?.origin).not.toContain("mcp.id.ai");
+  });
+});
+
+describe("isLoopbackUrl", () => {
+  it("is true only for the http IPv4 loopback literal", () => {
+    expect(isLoopbackUrl("http://127.0.0.1")).toBe(true);
+    expect(isLoopbackUrl("http://127.0.0.1:52341/callback")).toBe(true);
+    for (const raw of [
+      "https://127.0.0.1",
+      "http://localhost",
+      "http://[::1]",
+      "http://0.0.0.0",
+      "https://mcp.id.ai",
+      "not a url",
+    ]) {
+      expect(isLoopbackUrl(raw)).toBe(false);
+    }
+  });
+});
+
+describe("trustsOrigin", () => {
+  it("matches a remote server by exact origin", () => {
+    expect(trustsOrigin("https://mcp.id.ai/mcp", "https://mcp.id.ai")).toBe(
+      true,
+    );
+    expect(
+      trustsOrigin("https://mcp.id.ai/mcp", "https://mcp.id.ai:8443"),
+    ).toBe(false);
+    expect(trustsOrigin("https://mcp.id.ai/mcp", "https://evil.example")).toBe(
+      false,
+    );
+  });
+
+  it("matches a local server on any port, since it binds a fresh one", () => {
+    expect(trustsOrigin(LOCAL_MCP_SERVER_URL, "http://127.0.0.1:52341")).toBe(
+      true,
+    );
+    expect(trustsOrigin(LOCAL_MCP_SERVER_URL, "http://127.0.0.1:9")).toBe(true);
+  });
+
+  it("does not let a local entry trust anything off loopback", () => {
+    for (const origin of [
+      "https://evil.example",
+      "http://localhost:52341",
+      "http://[::1]:52341",
+      "https://127.0.0.1:52341",
+    ]) {
+      expect(trustsOrigin(LOCAL_MCP_SERVER_URL, origin)).toBe(false);
+    }
+  });
+
+  it("does not let a remote entry trust loopback", () => {
+    expect(trustsOrigin("https://mcp.id.ai", "http://127.0.0.1:52341")).toBe(
+      false,
+    );
   });
 });
 

--- a/src/frontend/src/lib/utils/mcpServer.ts
+++ b/src/frontend/src/lib/utils/mcpServer.ts
@@ -3,7 +3,30 @@
  * best-effort probe that it actually speaks MCP. Shared by the Settings UI
  * (where the user enters the URL) and the `/mcp` connect flow (which matches the
  * request's callback origin against the trusted server).
+ *
+ * Two kinds of server can be trusted:
+ *  - a **remote** one, at an https URL the user enters;
+ *  - a **local** one, a program listening on loopback. It is stored as the
+ *    port-less {@link LOCAL_MCP_SERVER_URL}, because a local server binds a
+ *    fresh port per sign-in (it cannot promise one ahead of time), so trust
+ *    matching for it is by host, not by origin — see {@link trustsOrigin}.
  */
+
+/** The stored trusted URL that stands for "a local server on this computer".
+ *  Port-less on purpose: the port is whatever the local program binds for the
+ *  sign-in it is starting, so the stored value is the stable part. */
+export const LOCAL_MCP_SERVER_URL = "http://127.0.0.1";
+
+/** The one loopback host a local server may listen on.
+ *
+ *  Only the IPv4 literal. Not `localhost` (a name, and so subject to whatever
+ *  resolves it), not `0.0.0.0`, and not a name that merely resolves to
+ *  loopback — those are rebinding surface, and the browser cannot be asked
+ *  where a name will point. Not `::1` either: CSP's host-source grammar can't
+ *  express IPv6 literals, so `http://[::1]:*` would be an invalid `form-action`
+ *  source that browsers ignore, and a `::1` callback would pass here only to
+ *  die at delivery — the same trap the /cli flow documents. */
+const LOOPBACK_HOSTNAME = "127.0.0.1";
 
 export interface McpServer {
   /** The URL the user entered, kept verbatim (not slash-normalized) so it
@@ -15,12 +38,54 @@ export interface McpServer {
   origin: string;
   /** host[:port], for display. */
   host: string;
+  /** Whether this is a local server on the loopback interface, which trust
+   *  matching treats by host rather than by origin. */
+  isLoopback: boolean;
 }
 
 /**
+ * Whether `url` names a local server on loopback — the port-less stored form
+ * as well as the ported callbacks a local server actually listens on.
+ */
+export const isLoopbackUrl = (url: string): boolean => {
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === "http:" && parsed.hostname === LOOPBACK_HOSTNAME;
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * Whether a server at `origin` is the one `trustedUrl` names.
+ *
+ * The single trust comparison, used both by the connect flow's pre-filter and
+ * by its authoritative gate against the *certified* `trusted_url` — one
+ * function so the two can't drift into disagreeing about what is trusted.
+ *
+ * Remote servers match by exact origin. A local server matches by host only:
+ * the stored URL carries no port because the program binds a fresh one per
+ * sign-in, so any port on the loopback host is the trusted server. That is a
+ * real widening, and it is the point — trusting a local server means trusting
+ * the programs on this computer, which is why enabling one is its own
+ * deliberate choice in Settings and why the connect flow says so before the
+ * first local sign-in on a machine.
+ */
+export const trustsOrigin = (trustedUrl: string, origin: string): boolean => {
+  if (isLoopbackUrl(trustedUrl)) {
+    return isLoopbackUrl(origin);
+  }
+  try {
+    return new URL(trustedUrl).origin === origin;
+  } catch {
+    return false;
+  }
+};
+
+/**
  * Parses an MCP server URL into its normalized parts, or `undefined` when it
- * isn't an acceptable target. MCP connections are to remote servers only, so
- * the URL must be https (a plain-http or loopback URL is rejected).
+ * isn't an acceptable target: an https URL for a remote server, or an
+ * `http://127.0.0.1[:port]` URL for a local one.
  */
 export const parseMcpServerUrl = (raw: string): McpServer | undefined => {
   const trimmed = raw.trim();
@@ -30,13 +95,14 @@ export const parseMcpServerUrl = (raw: string): McpServer | undefined => {
   } catch {
     return undefined;
   }
-  if (url.protocol !== "https:") {
+  const isLoopback = isLoopbackUrl(trimmed);
+  if (url.protocol !== "https:" && !isLoopback) {
     return undefined;
   }
   // Keep the URL as entered rather than `url.href`, which appends a trailing
   // slash to a bare origin. Trust matching is by origin; verification matches
   // the canonical resource URL.
-  return { url: trimmed, origin: url.origin, host: url.host };
+  return { url: trimmed, origin: url.origin, host: url.host, isLoopback };
 };
 
 /** MCP protocol revision we advertise in the `initialize` probe. */

--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/settings/components/McpAddConnectorDialog.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/settings/components/McpAddConnectorDialog.svelte
@@ -1,6 +1,12 @@
 <script lang="ts">
   import { onDestroy } from "svelte";
-  import { TriangleAlertIcon, RotateCwIcon, CheckIcon } from "@lucide/svelte";
+  import {
+    TriangleAlertIcon,
+    RotateCwIcon,
+    CheckIcon,
+    GlobeIcon,
+    MonitorIcon,
+  } from "@lucide/svelte";
   import Dialog from "$lib/components/ui/Dialog.svelte";
   import FeaturedIcon from "$lib/components/ui/FeaturedIcon.svelte";
   import HoldToConfirm from "$lib/components/ui/HoldToConfirm.svelte";
@@ -10,7 +16,11 @@
   import McpIcon from "$lib/components/icons/McpIcon.svelte";
   import { Trans } from "$lib/components/locale";
   import { t } from "$lib/stores/locale.store";
-  import { parseMcpServerUrl, probeMcpServer } from "$lib/utils/mcpServer";
+  import {
+    LOCAL_MCP_SERVER_URL,
+    parseMcpServerUrl,
+    probeMcpServer,
+  } from "$lib/utils/mcpServer";
   import { originOf } from "$lib/utils/mcpConfig";
   import { backendCanisterConfig } from "$lib/globals";
 
@@ -30,6 +40,15 @@
     | "invalid"
     | "official";
 
+  // Remote connectors are named by URL; a local one has nothing to enter. Its
+  // address is fixed and its port isn't knowable in advance (a local server
+  // binds a fresh one per sign-in), so it is a choice, not a text field — a URL
+  // box here would have to accept `http://127.0.0.1` and reject
+  // `http://127.0.0.1:8000`, and the reachability check beside it can't run
+  // against loopback at all.
+  type ConnectorKind = "remote" | "local";
+
+  let kind = $state<ConnectorKind>("remote");
   let urlInput = $state("");
   let verifyState = $state<VerifyState>("idle");
   let parsedUrl = $state<string | undefined>(undefined);
@@ -90,18 +109,24 @@
 
   const canConfirm = $derived(
     !saving &&
-      parsedUrl !== undefined &&
-      (verifyState === "ok" || verifyState === "unverified"),
+      (kind === "local" ||
+        (parsedUrl !== undefined &&
+          (verifyState === "ok" || verifyState === "unverified"))),
   );
 
   const handleConfirm = async () => {
-    if (parsedUrl === undefined) return;
+    const url = kind === "local" ? LOCAL_MCP_SERVER_URL : parsedUrl;
+    if (url === undefined) return;
     saving = true;
     try {
-      await onSave(parsedUrl);
+      await onSave(url);
     } finally {
       saving = false;
     }
+  };
+
+  const selectKind = (next: ConnectorKind) => {
+    kind = next;
   };
 
   const errorText = $derived(
@@ -148,6 +173,32 @@
       </p>
     </div>
 
+    <div
+      class="flex flex-row gap-3"
+      role="radiogroup"
+      aria-label={$t`Connector type`}
+    >
+      {#each [{ value: "remote", icon: GlobeIcon, label: $t`Remote server`, hint: $t`Hosted, by URL` }, { value: "local", icon: MonitorIcon, label: $t`On this computer`, hint: $t`A local program` }] as option (option.value)}
+        <button
+          type="button"
+          role="radio"
+          aria-checked={kind === option.value}
+          disabled={saving}
+          onclick={() => selectKind(option.value as ConnectorKind)}
+          class="flex flex-1 flex-col gap-1 rounded-lg border p-3 text-start {kind ===
+          option.value
+            ? 'border-border-brand bg-bg-brand-primary'
+            : 'border-border-tertiary bg-bg-primary'}"
+        >
+          <option.icon class="text-fg-secondary size-4.5" aria-hidden="true" />
+          <span class="text-text-primary text-sm font-semibold"
+            >{option.label}</span
+          >
+          <span class="text-text-tertiary text-xs">{option.hint}</span>
+        </button>
+      {/each}
+    </div>
+
     <ul class="my-2 flex flex-col gap-5">
       <li class="flex flex-row items-start gap-3">
         <TriangleAlertIcon
@@ -177,56 +228,78 @@
           </span>
         </div>
       </li>
+      {#if kind === "local"}
+        <li class="flex flex-row items-start gap-3">
+          <MonitorIcon
+            class="text-fg-secondary mt-0.5 size-4.5 shrink-0"
+            aria-hidden="true"
+          />
+          <div class="flex flex-col gap-0.5 text-sm">
+            <span class="text-text-primary font-semibold">
+              {$t`Any local program can connect`}
+            </span>
+            <span class="text-text-tertiary">
+              {$t`A local server picks a new port each time, so any program on this computer can ask to connect. Remove it when you're not using one.`}
+            </span>
+          </div>
+        </li>
+      {/if}
     </ul>
 
-    <div class="flex flex-col gap-1.5">
-      <span class="text-text-secondary text-sm font-medium">
-        {$t`Connector URL`}
-      </span>
-      <div class="relative">
-        <Input
-          bind:value={urlInput}
-          oninput={handleInput}
-          onblur={handleBlur}
-          placeholder="https://mcp.example.com/mcp"
-          aria-label={$t`MCP server URL`}
-          error={errorText}
-          disabled={saving}
-          autocomplete="off"
-          autocapitalize="off"
-          spellcheck={false}
-          inputClass="pe-11 font-mono text-sm"
-        />
-        <div
-          class="pointer-events-none absolute inset-y-0 inset-e-3 flex items-center"
-        >
-          {#if verifyState === "checking"}
-            <ProgressRing class="text-fg-tertiary size-5" />
-          {:else if verifyState === "ok"}
-            <Tooltip label={$t`Reachable MCP server`}>
-              <span
-                class="bg-bg-success-primary text-fg-success-primary pointer-events-auto flex size-5 items-center justify-center rounded-full"
-                aria-label={$t`Reachable MCP server`}
+    {#if kind === "local"}
+      <p class="text-text-tertiary text-sm text-pretty">
+        {$t`Your local server tells you when it's ready to connect. Nothing to enter here.`}
+      </p>
+    {:else}
+      <div class="flex flex-col gap-1.5">
+        <span class="text-text-secondary text-sm font-medium">
+          {$t`Connector URL`}
+        </span>
+        <div class="relative">
+          <Input
+            bind:value={urlInput}
+            oninput={handleInput}
+            onblur={handleBlur}
+            placeholder="https://mcp.example.com/mcp"
+            aria-label={$t`MCP server URL`}
+            error={errorText}
+            disabled={saving}
+            autocomplete="off"
+            autocapitalize="off"
+            spellcheck={false}
+            inputClass="pe-11 font-mono text-sm"
+          />
+          <div
+            class="pointer-events-none absolute inset-y-0 inset-e-3 flex items-center"
+          >
+            {#if verifyState === "checking"}
+              <ProgressRing class="text-fg-tertiary size-5" />
+            {:else if verifyState === "ok"}
+              <Tooltip label={$t`Reachable MCP server`}>
+                <span
+                  class="bg-bg-success-primary text-fg-success-primary pointer-events-auto flex size-5 items-center justify-center rounded-full"
+                  aria-label={$t`Reachable MCP server`}
+                >
+                  <CheckIcon class="size-3.5" />
+                </span>
+              </Tooltip>
+            {:else if verifyState === "unverified" && parsedUrl !== undefined}
+              <Tooltip
+                label={$t`Couldn't validate MCP support`}
+                description={$t`We couldn't validate MCP support at this URL, but you can still trust it.`}
               >
-                <CheckIcon class="size-3.5" />
-              </span>
-            </Tooltip>
-          {:else if verifyState === "unverified" && parsedUrl !== undefined}
-            <Tooltip
-              label={$t`Couldn't validate MCP support`}
-              description={$t`We couldn't validate MCP support at this URL, but you can still trust it.`}
-            >
-              <span
-                class="border-border-secondary text-fg-tertiary pointer-events-auto flex size-5 items-center justify-center rounded-full border"
-                aria-label={$t`Couldn't validate MCP support`}
-              >
-                <TriangleAlertIcon class="size-3" />
-              </span>
-            </Tooltip>
-          {/if}
+                <span
+                  class="border-border-secondary text-fg-tertiary pointer-events-auto flex size-5 items-center justify-center rounded-full border"
+                  aria-label={$t`Couldn't validate MCP support`}
+                >
+                  <TriangleAlertIcon class="size-3" />
+                </span>
+              </Tooltip>
+            {/if}
+          </div>
         </div>
       </div>
-    </div>
+    {/if}
 
     <HoldToConfirm
       label={$t`Hold to continue`}

--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/settings/components/McpAddConnectorDialog.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/settings/components/McpAddConnectorDialog.svelte
@@ -49,6 +49,21 @@
   type ConnectorKind = "remote" | "local";
 
   let kind = $state<ConnectorKind>("remote");
+
+  const connectorKinds = $derived([
+    {
+      value: "remote" as const,
+      icon: GlobeIcon,
+      label: $t`Remote server`,
+      hint: $t`Hosted, by URL`,
+    },
+    {
+      value: "local" as const,
+      icon: MonitorIcon,
+      label: $t`On this computer`,
+      hint: $t`A local program`,
+    },
+  ]);
   let urlInput = $state("");
   let verifyState = $state<VerifyState>("idle");
   let parsedUrl = $state<string | undefined>(undefined);
@@ -173,31 +188,35 @@
       </p>
     </div>
 
-    <div
-      class="flex flex-row gap-3"
-      role="radiogroup"
-      aria-label={$t`Connector type`}
-    >
-      {#each [{ value: "remote", icon: GlobeIcon, label: $t`Remote server`, hint: $t`Hosted, by URL` }, { value: "local", icon: MonitorIcon, label: $t`On this computer`, hint: $t`A local program` }] as option (option.value)}
-        <button
-          type="button"
-          role="radio"
-          aria-checked={kind === option.value}
-          disabled={saving}
-          onclick={() => selectKind(option.value as ConnectorKind)}
-          class="flex flex-1 flex-col gap-1 rounded-lg border p-3 text-start {kind ===
+    <!-- Native radios rather than ARIA-annotated buttons: the choice is
+         mutually exclusive, so this gets arrow-key navigation, roving focus and
+         the right announcement without reimplementing any of it. The input is
+         visually hidden and the card is the label. -->
+    <fieldset class="flex flex-row gap-3" disabled={saving}>
+      <legend class="sr-only">{$t`Connector type`}</legend>
+      {#each connectorKinds as option (option.value)}
+        <label
+          class="flex flex-1 cursor-pointer flex-col gap-1 rounded-lg border p-3 focus-within:outline focus-within:outline-2 focus-within:outline-offset-2 {kind ===
           option.value
             ? 'border-border-brand bg-bg-brand-primary'
             : 'border-border-tertiary bg-bg-primary'}"
         >
+          <input
+            type="radio"
+            name="connector-kind"
+            value={option.value}
+            checked={kind === option.value}
+            onchange={() => selectKind(option.value)}
+            class="sr-only"
+          />
           <option.icon class="text-fg-secondary size-4.5" aria-hidden="true" />
-          <span class="text-text-primary text-sm font-semibold"
-            >{option.label}</span
-          >
+          <span class="text-text-primary text-sm font-semibold">
+            {option.label}
+          </span>
           <span class="text-text-tertiary text-xs">{option.hint}</span>
-        </button>
+        </label>
       {/each}
-    </div>
+    </fieldset>
 
     <ul class="my-2 flex flex-col gap-5">
       <li class="flex flex-row items-start gap-3">

--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/settings/components/McpTrustedServersSection.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/settings/components/McpTrustedServersSection.svelte
@@ -2,11 +2,13 @@
   import { invalidateAll } from "$app/navigation";
   import {
     BotIcon,
+    MonitorIcon,
     RotateCcwIcon,
     SlidersHorizontalIcon,
     Trash2Icon,
   } from "@lucide/svelte";
   import McpIcon from "$lib/components/icons/McpIcon.svelte";
+  import { isLoopbackUrl } from "$lib/utils/mcpServer";
   import Badge from "$lib/components/ui/Badge.svelte";
   import Toggle from "$lib/components/ui/Toggle.svelte";
   import { toaster } from "$lib/components/utils/toaster";
@@ -47,7 +49,14 @@
     const url = trustedUrl(config, backendCanisterConfig);
     return url === undefined
       ? undefined
-      : { url, custom: trusted !== undefined };
+      : {
+          url,
+          custom: trusted !== undefined,
+          // A local connector is stored port-less, because the program binds a
+          // fresh port per sign-in. So it is named by what it is rather than by
+          // a host that would read like a remote one.
+          local: isLoopbackUrl(url),
+        };
   });
   // The switch reports whether a connector is actually trusted, not what the
   // stored `enabled` flag says: on a deployment without an official connector,
@@ -186,16 +195,28 @@
           class="border-border-secondary bg-bg-secondary text-fg-tertiary flex size-10 shrink-0 items-center justify-center rounded-md border"
           aria-hidden="true"
         >
-          <McpIcon class="size-4.5" />
+          {#if active.local}
+            <MonitorIcon class="size-4.5" />
+          {:else}
+            <McpIcon class="size-4.5" />
+          {/if}
         </span>
 
         <div class="flex min-w-0 flex-1 flex-col gap-1">
           <span class="text-text-primary truncate text-sm font-semibold">
-            {active.custom ? hostOf(active.url) : $t`Internet Computer MCP`}
+            {#if active.local}
+              {$t`Local server`}
+            {:else if active.custom}
+              {hostOf(active.url)}
+            {:else}
+              {$t`Internet Computer MCP`}
+            {/if}
           </span>
           <span class="text-text-secondary text-sm">
             {#if !active.custom}
               {$t`Official · Hosted by DFINITY`}
+            {:else if active.local}
+              {$t`Runs on your own computer · Any port`}
             {:else if official !== undefined}
               {$t`Added by you · Replaces the official connector`}
             {:else}

--- a/src/frontend/src/routes/(new-styling)/mcp/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/mcp/+page.svelte
@@ -22,7 +22,9 @@
   import McpCloseWindowView from "./views/McpCloseWindowView.svelte";
   import McpInvalidView from "./views/McpInvalidView.svelte";
   import McpUntrustedView from "./views/McpUntrustedView.svelte";
+  import McpLocalServerNoticeView from "./views/McpLocalServerNoticeView.svelte";
   import McpConnectingView from "./views/McpConnectingView.svelte";
+  import { localServerNoticeStore } from "./local-server-notice.store";
   import ManageHandoff from "$lib/components/ui/ManageHandoff.svelte";
   import { ManageHandoffFlow } from "$lib/flows/manageHandoffFlow.svelte";
   import {
@@ -40,13 +42,14 @@
   const params = $derived(data.params);
 
   // The MCP server the user is connecting is identified by the origin of the
-  // request's callback: each user trusts whichever (remote) server they connect.
-  // The connect flow delivers the registration delegation to that callback —
-  // once `mcpAuthorize` has confirmed the origin is trusted and matched it
-  // against the allow-list the server declares on its origin. MCP is
-  // remote-only, so only https callbacks are accepted (a plain-http or loopback
-  // callback is rejected). A disallowed (or unparsable) callback yields
-  // `undefined` → the invalid screen.
+  // request's callback: each user trusts whichever server they connect. The
+  // connect flow delivers the registration delegation to that callback — once
+  // `mcpAuthorize` has confirmed the origin is the trusted one and, for a
+  // remote server, matched the callback against the allow-list that server
+  // declares. Two shapes are accepted: an https callback for a remote server,
+  // and an `http://127.0.0.1[:port]` one for a local server on this computer.
+  // Anything else (or an unparsable callback) yields `undefined` → the invalid
+  // screen.
   const mcpServer = $derived(
     params.kind === "valid" ? parseMcpServerUrl(params.callback) : undefined,
   );
@@ -78,10 +81,31 @@
   type Phase =
     | { kind: "wizard" }
     | { kind: "authorize" }
+    | { kind: "local-notice" }
     | { kind: "untrusted" }
     | { kind: "connecting" }
     | { kind: "close"; redirecting: boolean }
     | { kind: "invalid" };
+
+  // The identity that accepted the local-server notice in this tab. Held here
+  // rather than written straight to the device store, so a connect that goes on
+  // to be refused (a crafted link naming a loopback callback the identity
+  // doesn't actually permit) can't leave an "already told" behind that would
+  // make the next attempt one screen quieter. It is committed on success.
+  let noticeAcceptedFor = $state<bigint | undefined>(undefined);
+
+  // The connect screen, or the local-server notice that precedes it the first
+  // time this identity signs in to a local server on this computer. Answerable
+  // without the canister — the callback comes from the fragment and the record
+  // is device-local — so it can run before the identity has authenticated,
+  // which is what lets the notice come *before* the consent screen rather than
+  // after the user has already approved the connect.
+  const connectPhase = (identityNumber: bigint): Phase =>
+    mcpServer?.isLoopback === true &&
+    noticeAcceptedFor !== identityNumber &&
+    !localServerNoticeStore.isAcknowledged(identityNumber)
+      ? { kind: "local-notice" }
+      : { kind: "authorize" };
 
   // The phase the page opens on: a returning user with a previously-used
   // identity opens on the connect screen, and a user with no last-used identity
@@ -103,7 +127,7 @@
     if (selected === undefined) {
       return { kind: "wizard" };
     }
-    return { kind: "authorize" };
+    return connectPhase(selected.identityNumber);
   };
 
   let phase = $state<Phase>(initialPhase());
@@ -122,6 +146,7 @@
     showIdentitySwitcher.set(
       phase.kind === "wizard" ||
         phase.kind === "authorize" ||
+        phase.kind === "local-notice" ||
         phase.kind === "untrusted",
     );
   });
@@ -140,6 +165,7 @@
     if (
       phase.kind !== "wizard" &&
       phase.kind !== "authorize" &&
+      phase.kind !== "local-notice" &&
       phase.kind !== "untrusted"
     ) {
       return;
@@ -157,7 +183,7 @@
     }
     if (selected.identityNumber !== phaseIdentity) {
       phaseIdentity = selected.identityNumber;
-      phase = { kind: "authorize" };
+      phase = connectPhase(selected.identityNumber);
     }
   });
 
@@ -289,6 +315,14 @@
           registrationKey: fromBase64URL(request.registrationKey),
         });
         mcpAuthorizeFunnel.trigger(McpAuthorizeEvents.Success);
+        // Trust held and the delegation is minted, so the local-server notice
+        // has been earned: record it for this identity on this computer, and
+        // don't show it again here. Committed only now — never at the moment
+        // the user accepted it — so an attempt that ended at the untrusted
+        // screen leaves the next one just as loud.
+        if (server.isLoopback) {
+          localServerNoticeStore.acknowledge(authenticated.identityNumber);
+        }
         // The registration delegation is minted: reach the terminal close
         // screen first, so the page is in the truthful state even when the
         // navigation below never replaces the document or the user comes Back
@@ -323,6 +357,23 @@
   // identity". The returning-user untrusted screen often isn't authenticated
   // yet, so this runs the full ceremony when needed.
   const manageHandoff = new ManageHandoffFlow();
+  // The local-server notice: continuing goes on to the consent screen, which
+  // still gates this connect and every later one. Cancelling drops the connect
+  // rather than proceeding silently, so declining actually declines.
+  const handleLocalNoticeContinue = (): void => {
+    const selected = $lastUsedIdentitiesStore.selected;
+    if (selected === undefined) {
+      return;
+    }
+    noticeAcceptedFor = selected.identityNumber;
+    phase = { kind: "authorize" };
+  };
+
+  const handleLocalNoticeCancel = (): void => {
+    mcpAuthorizeFunnel.trigger(McpAuthorizeEvents.Error);
+    phase = { kind: "close", redirecting: false };
+  };
+
   const handleManageTrustedServer = (): void => {
     const selected = $lastUsedIdentitiesStore.selected;
     if (selected === undefined) {
@@ -376,6 +427,12 @@
     mcpServerOrigin={mcpServer.origin}
     requestedTtlSeconds={params.kind === "valid" ? params.ttlSeconds : 3600}
     onAuthorize={handleAuthorize}
+  />
+{:else if phase.kind === "local-notice" && mcpServer !== undefined}
+  <McpLocalServerNoticeView
+    mcpServerHost={mcpServer.host}
+    onContinue={handleLocalNoticeContinue}
+    onCancel={handleLocalNoticeCancel}
   />
 {:else if phase.kind === "untrusted" && mcpServer !== undefined}
   <McpUntrustedView

--- a/src/frontend/src/routes/(new-styling)/mcp/local-server-notice.store.ts
+++ b/src/frontend/src/routes/(new-styling)/mcp/local-server-notice.store.ts
@@ -1,0 +1,49 @@
+import { get, type Readable } from "svelte/store";
+import { storeLocalStorageKey } from "$lib/constants/store.constants";
+import { writableStored } from "$lib/stores/writable.store";
+
+/**
+ * Which identities have already signed in to a local MCP server on *this*
+ * computer, so the notice that precedes the first such sign-in is shown once
+ * per identity per machine.
+ *
+ * This is a record, not a permission. What a local server may do is decided by
+ * the identity's synced config (which the user can revoke from any device,
+ * taking the live session with it) and by the consent screen on every connect.
+ * All this store decides is whether the user has already been told that the
+ * connector they are signing in to is a program on their own computer.
+ *
+ * Device-local because the fact it records is device-local: the identity's
+ * permission to use a local connector follows it everywhere, but "you have
+ * already been shown this here" is only ever true of one machine.
+ */
+type LocalServerNoticeState = {
+  [identityNumber: string]: boolean;
+};
+
+type LocalServerNoticeStore = Readable<LocalServerNoticeState> & {
+  isAcknowledged: (identityNumber: bigint) => boolean;
+  acknowledge: (identityNumber: bigint) => void;
+};
+
+export const initLocalServerNoticeStore = (): LocalServerNoticeStore => {
+  const store = writableStored<LocalServerNoticeState>({
+    key: storeLocalStorageKey.McpLocalServerNotice,
+    defaultValue: {},
+    version: 1,
+  });
+
+  return {
+    subscribe: store.subscribe,
+    isAcknowledged: (identityNumber) =>
+      get(store)[identityNumber.toString()] === true,
+    acknowledge: (identityNumber) => {
+      store.update((state) => ({
+        ...state,
+        [identityNumber.toString()]: true,
+      }));
+    },
+  };
+};
+
+export const localServerNoticeStore = initLocalServerNoticeStore();

--- a/src/frontend/src/routes/(new-styling)/mcp/utils.test.ts
+++ b/src/frontend/src/routes/(new-styling)/mcp/utils.test.ts
@@ -100,6 +100,10 @@ const browserKeyOf = (actor: ReturnType<typeof makeActor>): Uint8Array =>
 const authorize = (
   actor: ReturnType<typeof makeActor>,
   accessLevel: "read-only" | "full-access",
+  server: { origin: string; callback: string } = {
+    origin: MCP_ORIGIN,
+    callback: CALLBACK,
+  },
 ) =>
   mcpAuthorize({
     authenticated: {
@@ -108,11 +112,29 @@ const authorize = (
     } as unknown as Authenticated,
     ttlSeconds: TTL_SECONDS,
     accessLevel,
-    serverOrigin: MCP_ORIGIN,
-    requestedCallback: CALLBACK,
+    serverOrigin: server.origin,
+    requestedCallback: server.callback,
     state: STATE,
     registrationKey: REGISTRATION_KEY,
   });
+
+/** A local server: the port-less stored trusted URL, and the ported loopback
+ *  callback the program is actually listening on for this sign-in. */
+const LOCAL_TRUSTED_URL = "http://127.0.0.1";
+const LOCAL_ORIGIN = "http://127.0.0.1:52341";
+const LOCAL_CALLBACK = `${LOCAL_ORIGIN}/callback`;
+
+/** `prepare` answering with a local server as the identity's trusted one. */
+const withLocalTrustedUrl = (actor: ReturnType<typeof makeActor>) => {
+  actor.prepare_mcp_registration_delegation.mockResolvedValue({
+    Ok: {
+      user_key: USER_KEY,
+      expiration: actor.expiration,
+      trusted_url: LOCAL_TRUSTED_URL,
+    },
+  });
+  return actor;
+};
 
 beforeEach(() => {
   // The connect's only network call of its own is the trusted server's
@@ -255,6 +277,94 @@ describe("mcpAuthorize trust gate (certified trusted_url)", () => {
 
     const url = await authorize(actor, "read-only");
     expect(url.startsWith(`${CALLBACK}#`)).toBe(true);
+  });
+});
+
+describe("mcpAuthorize local server (loopback)", () => {
+  it("delivers without fetching an allow-list", async () => {
+    // Browsers block this https document from fetching a loopback URL, so the
+    // allow-list can't be read and a local connect must not depend on it.
+    const actor = withLocalTrustedUrl(makeActor());
+
+    const url = await authorize(actor, "read-only", {
+      origin: LOCAL_ORIGIN,
+      callback: LOCAL_CALLBACK,
+    });
+
+    expect(vi.mocked(fetch)).not.toHaveBeenCalled();
+    expect(url.startsWith(`${LOCAL_CALLBACK}#`)).toBe(true);
+  });
+
+  it("accepts any port, since the local server binds a fresh one per sign-in", async () => {
+    const actor = withLocalTrustedUrl(makeActor());
+
+    const url = await authorize(actor, "read-only", {
+      origin: "http://127.0.0.1:9",
+      callback: "http://127.0.0.1:9/callback",
+    });
+
+    expect(url.startsWith("http://127.0.0.1:9/callback#")).toBe(true);
+  });
+
+  it("still refuses an origin that is not loopback at all", async () => {
+    // The port is free; the host is not. A local trusted entry must never
+    // authorize delivery to a remote origin.
+    const actor = withLocalTrustedUrl(makeActor());
+
+    await expect(
+      authorize(actor, "read-only", {
+        origin: "https://evil.example",
+        callback: "https://evil.example/callback",
+      }),
+    ).rejects.toBeInstanceOf(McpUntrustedServerError);
+    expect(actor.get_mcp_registration_delegation).not.toHaveBeenCalled();
+  });
+
+  it("refuses loopback lookalikes", async () => {
+    for (const origin of [
+      "http://localhost:52341",
+      "http://[::1]:52341",
+      "https://127.0.0.1:52341",
+      "http://127.0.0.1.nip.io:52341",
+    ]) {
+      const actor = withLocalTrustedUrl(makeActor());
+      await expect(
+        authorize(actor, "read-only", {
+          origin,
+          callback: `${origin}/callback`,
+        }),
+      ).rejects.toBeInstanceOf(McpUntrustedServerError);
+    }
+  });
+
+  it("does not let a remote trusted server authorize a loopback callback", async () => {
+    // The mirror of the above: a crafted link naming a local callback must not
+    // ride an identity whose trusted server is remote.
+    const actor = makeActor();
+
+    await expect(
+      authorize(actor, "read-only", {
+        origin: LOCAL_ORIGIN,
+        callback: LOCAL_CALLBACK,
+      }),
+    ).rejects.toBeInstanceOf(McpUntrustedServerError);
+    expect(vi.mocked(fetch)).not.toHaveBeenCalled();
+    expect(actor.get_mcp_registration_delegation).not.toHaveBeenCalled();
+  });
+
+  it("keeps enforcing the allow-list for a remote server", async () => {
+    // The loopback exemption must not leak into the remote path.
+    const actor = makeActor();
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(JSON.stringify({ callbacks: [`${MCP_ORIGIN}/other`] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    await expect(authorize(actor, "read-only")).rejects.toThrow(
+      /does not declare this callback/,
+    );
   });
 });
 
@@ -453,6 +563,41 @@ describe("isOriginTrusted", () => {
     expect(
       isOriginTrusted(trust("not a url"), "https://mcp.id.ai", NO_OFFICIAL),
     ).toBe(false);
+  });
+});
+
+describe("isOriginTrusted — local server", () => {
+  const OFFICIAL = {
+    mcp_official_url: [] as [] | [string],
+  } as Pick<BackendCanisterConfig, "mcp_official_url">;
+  const local = (enabled: boolean): McpConfig => ({
+    enabled,
+    url: "http://127.0.0.1",
+  });
+
+  it("trusts any loopback port", () => {
+    expect(
+      isOriginTrusted(local(true), "http://127.0.0.1:52341", OFFICIAL),
+    ).toBe(true);
+    expect(isOriginTrusted(local(true), "http://127.0.0.1:1", OFFICIAL)).toBe(
+      true,
+    );
+  });
+
+  it("still requires the feature enabled", () => {
+    expect(
+      isOriginTrusted(local(false), "http://127.0.0.1:52341", OFFICIAL),
+    ).toBe(false);
+  });
+
+  it("trusts nothing off loopback", () => {
+    for (const origin of [
+      "https://mcp.id.ai",
+      "http://localhost:52341",
+      "https://127.0.0.1:52341",
+    ]) {
+      expect(isOriginTrusted(local(true), origin, OFFICIAL)).toBe(false);
+    }
   });
 });
 

--- a/src/frontend/src/routes/(new-styling)/mcp/utils.test.ts
+++ b/src/frontend/src/routes/(new-styling)/mcp/utils.test.ts
@@ -337,6 +337,36 @@ describe("mcpAuthorize local server (loopback)", () => {
     }
   });
 
+  it("refuses a callback that already carries a fragment", async () => {
+    // Delivery appends its own fragment; one already there would produce
+    // `...#theirs#delegation=...` and mangle what the server reads. Skipping
+    // the allow-list drops the question of *which* callback, not whether the
+    // answer can be delivered to.
+    const actor = withLocalTrustedUrl(makeActor());
+
+    await expect(
+      authorize(actor, "read-only", {
+        origin: LOCAL_ORIGIN,
+        callback: `${LOCAL_CALLBACK}#already`,
+      }),
+    ).rejects.toThrow(/must not carry a fragment/);
+    expect(actor.get_mcp_registration_delegation).not.toHaveBeenCalled();
+  });
+
+  it("refuses a callback that is not on the confirmed origin", async () => {
+    // Belt and braces: today `serverOrigin` is derived from this very callback,
+    // so they cannot disagree — the check keeps the invariant local anyway.
+    const actor = withLocalTrustedUrl(makeActor());
+
+    await expect(
+      authorize(actor, "read-only", {
+        origin: LOCAL_ORIGIN,
+        callback: "http://127.0.0.1:9999/callback",
+      }),
+    ).rejects.toThrow(/not on the trusted server's origin/);
+    expect(actor.get_mcp_registration_delegation).not.toHaveBeenCalled();
+  });
+
   it("does not let a remote trusted server authorize a loopback callback", async () => {
     // The mirror of the above: a crafted link naming a local callback must not
     // ride an identity whose trusted server is remote.

--- a/src/frontend/src/routes/(new-styling)/mcp/utils.ts
+++ b/src/frontend/src/routes/(new-styling)/mcp/utils.ts
@@ -1,5 +1,6 @@
 import { toPermissionsArg, type AccessLevel } from "$lib/utils/accessLevel";
-import { originOf, type McpConfig } from "$lib/utils/mcpConfig";
+import type { McpConfig } from "$lib/utils/mcpConfig";
+import { isLoopbackUrl, trustsOrigin } from "$lib/utils/mcpServer";
 import { matchDeclaredCallback } from "$lib/utils/authCallbacks";
 import type { BackendCanisterConfig } from "$lib/globals";
 import type { Authenticated } from "$lib/stores/authentication.store";
@@ -36,10 +37,11 @@ interface McpAuthorizeInput {
    *  query can't redirect delivery to an attacker's origin. */
   serverOrigin: string;
   /** The exact callback the (attacker-craftable) connect link requested. Once
-   *  `serverOrigin` is trust-confirmed, it is matched against the allow-list
-   *  the server declares at a fixed well-known path on its origin (see
-   *  `matchDeclaredCallback`) — the link only ever selects among the declared
-   *  entries. This is where II delivers the registration delegation (a
+   *  `serverOrigin` is trust-confirmed, a *remote* server's callback is matched
+   *  against the allow-list it declares at a fixed well-known path on its
+   *  origin (see `matchDeclaredCallback`), so the link only ever selects among
+   *  the declared entries; a *local* server's is taken as-is, for the reasons
+   *  at the call site. This is where II delivers the registration delegation (a
    *  top-level navigation carrying it in the fragment). */
   requestedCallback: string;
   /** Opaque value the server issued for this connect, delivered back alongside
@@ -89,11 +91,11 @@ interface McpAuthorizeInput {
  * declared callback.
  *
  * Delivery is gated here, on values that can't be forged by a single node: the
- * connect link's origin must equal the origin of `prepare`'s `trusted_url`
+ * connect link's origin must be the server `prepare`'s `trusted_url` names
  * (certified, since `prepare` is an update call — so a forged `mcp_get_config`
- * query can't redirect delivery to an attacker's origin), and only then is the
- * link's callback matched against the allow-list the server declares on that
- * origin. A trust mismatch throws {@link McpUntrustedServerError} before the
+ * query can't redirect delivery to an attacker's origin), and only then, for a
+ * remote server, is the link's callback matched against the allow-list that
+ * server declares. A trust mismatch throws {@link McpUntrustedServerError} before the
  * chain is fetched or assembled, so the minted registration stays inert and
  * expires undelivered. Resolves with the delivery URL the caller should
  * navigate the tab to; the server's callback finishes the flow on its side
@@ -160,15 +162,33 @@ export const mcpAuthorize = async ({
   // link's origin is that trusted origin; on a mismatch we throw before
   // fetching `get` or assembling the chain, so the registration `prepare` just
   // minted is never turned into a redeemable artifact and simply expires.
-  if (originOf(trusted_url) !== serverOrigin) {
+  if (!trustsOrigin(trusted_url, serverOrigin)) {
     throw new McpUntrustedServerError();
   }
 
-  // Trust confirmed: only now contact the server for its declared-callback
-  // allow-list, and require the link's callback to exact-match a declared
-  // entry (so a crafted link can't point II at an arbitrary path on the trusted
-  // origin). Failure here fails the connect closed, before delivery.
-  const callback = await matchDeclaredCallback(serverOrigin, requestedCallback);
+  // Trust confirmed. For a remote server, contact it for its declared-callback
+  // allow-list and require the link's callback to exact-match a declared entry
+  // (so a crafted link can't point II at an arbitrary path on the trusted
+  // origin). Failure there fails the connect closed, before delivery.
+  //
+  // A local server is exempt, because the check cannot be made: browsers block
+  // this https document from fetching a loopback URL, so the request never
+  // reaches the local server and every local connect would fail closed. The
+  // allow-list defends against a *path* on a shared origin that leaks what is
+  // delivered to it — a public host can carry pages many parties wrote, so the
+  // origin alone doesn't say who receives the delegation. A local server is one
+  // program the user chose to run, and any port on this computer is trusted
+  // anyway (the stored URL carries none), so pinning the path would be defeated
+  // by naming a different port. What stands in its place is the deliberate
+  // Settings opt-in, the notice before the first local sign-in on a machine,
+  // and the consent screen on every connect.
+  //
+  // Decided on the *certified* `trusted_url`, never on the link: the two are
+  // equal by the gate above, but reading it from the certified value keeps this
+  // branch impossible to steer from the fragment.
+  const callback = isLoopbackUrl(trusted_url)
+    ? requestedCallback
+    : await matchDeclaredCallback(serverOrigin, requestedCallback);
 
   // `get` recovers the seed from `user_key` (the value `prepare` returned), so
   // it needs neither the consent params nor a deterministic re-derivation.
@@ -221,8 +241,8 @@ export const mcpAuthorize = async ({
  *
  * Takes the canister config rather than a bare URL so the official connector
  * can only come from the deployment, never from an arbitrary string at a call
- * site. Matching is by origin, the same boundary the delegation uses (II
- * derives a per-origin principal; the path can't scope it).
+ * site. Matching goes through {@link trustsOrigin} — by exact origin for a
+ * remote server, by loopback host for a local one.
  */
 export const isOriginTrusted = (
   config: McpConfig | undefined,
@@ -233,5 +253,5 @@ export const isOriginTrusted = (
     config !== undefined && config.enabled
       ? (config.url ?? mcp_official_url[0])
       : undefined;
-  return url !== undefined && originOf(url) === origin;
+  return url !== undefined && trustsOrigin(url, origin);
 };

--- a/src/frontend/src/routes/(new-styling)/mcp/utils.ts
+++ b/src/frontend/src/routes/(new-styling)/mcp/utils.ts
@@ -1,7 +1,10 @@
 import { toPermissionsArg, type AccessLevel } from "$lib/utils/accessLevel";
 import type { McpConfig } from "$lib/utils/mcpConfig";
 import { isLoopbackUrl, trustsOrigin } from "$lib/utils/mcpServer";
-import { matchDeclaredCallback } from "$lib/utils/authCallbacks";
+import {
+  assertDeliverableCallback,
+  matchDeclaredCallback,
+} from "$lib/utils/authCallbacks";
 import type { BackendCanisterConfig } from "$lib/globals";
 import type { Authenticated } from "$lib/stores/authentication.store";
 import type { PublicKey } from "@icp-sdk/core/agent";
@@ -183,11 +186,16 @@ export const mcpAuthorize = async ({
   // Settings opt-in, the notice before the first local sign-in on a machine,
   // and the consent screen on every connect.
   //
+  // Either way the callback still has to be deliverable — on the trust-confirmed
+  // origin and carrying no fragment of its own, since this flow appends one.
+  // Skipping the allow-list drops the question of *which* callback, never
+  // whether the answer can be delivered to.
+  //
   // Decided on the *certified* `trusted_url`, never on the link: the two are
   // equal by the gate above, but reading it from the certified value keeps this
   // branch impossible to steer from the fragment.
   const callback = isLoopbackUrl(trusted_url)
-    ? requestedCallback
+    ? assertDeliverableCallback(serverOrigin, requestedCallback)
     : await matchDeclaredCallback(serverOrigin, requestedCallback);
 
   // `get` recovers the seed from `user_key` (the value `prepare` returned), so

--- a/src/frontend/src/routes/(new-styling)/mcp/views/McpLocalServerNoticeView.svelte
+++ b/src/frontend/src/routes/(new-styling)/mcp/views/McpLocalServerNoticeView.svelte
@@ -1,0 +1,50 @@
+<script lang="ts">
+  import { MonitorIcon } from "@lucide/svelte";
+  import AuthPanel from "$lib/components/layout/AuthPanel.svelte";
+  import FeaturedIcon from "$lib/components/ui/FeaturedIcon.svelte";
+  import Badge from "$lib/components/ui/Badge.svelte";
+  import Ellipsis from "$lib/components/utils/Ellipsis.svelte";
+  import { t } from "$lib/stores/locale.store";
+
+  interface Props {
+    /** Host of the local server being connected (e.g. 127.0.0.1:52341). */
+    mcpServerHost: string;
+    onContinue: () => void;
+    onCancel: () => void;
+  }
+
+  const { mcpServerHost, onContinue, onCancel }: Props = $props();
+</script>
+
+<!--
+  Shown once per identity per computer, before the first sign-in to a local MCP
+  server on this machine. A local connector is trusted by host and not by port,
+  so this is where the user is told what that means; the consent screen that
+  follows still gates this and every later connect.
+-->
+<div class="flex w-full justify-center max-sm:flex-1 sm:max-w-110">
+  <AuthPanel>
+    <FeaturedIcon size="lg" variant="warning" class="mb-5 self-start">
+      <MonitorIcon class="size-6" />
+    </FeaturedIcon>
+
+    <h1 class="text-text-primary text-2xl font-medium">
+      {$t`Allow local programs to connect?`}
+    </h1>
+    <div class="mt-4 self-start">
+      <Badge size="sm" class="max-w-full">
+        <Ellipsis text={mcpServerHost} position="middle" />
+      </Badge>
+    </div>
+    <p class="text-text-tertiary mt-4 text-base text-pretty">
+      {$t`Any program on this computer can ask. We won't ask again here.`}
+    </p>
+
+    <button onclick={onContinue} class="btn btn-primary btn-xl mt-8 w-full">
+      {$t`Continue`}
+    </button>
+    <button onclick={onCancel} class="btn btn-tertiary btn-xl mt-3 w-full">
+      {$t`Cancel`}
+    </button>
+  </AuthPanel>
+</div>

--- a/src/frontend/src/routes/(new-styling)/mcp/views/McpLocalServerNoticeView.svelte
+++ b/src/frontend/src/routes/(new-styling)/mcp/views/McpLocalServerNoticeView.svelte
@@ -17,10 +17,12 @@
 </script>
 
 <!--
-  Shown once per identity per computer, before the first sign-in to a local MCP
-  server on this machine. A local connector is trusted by host and not by port,
-  so this is where the user is told what that means; the consent screen that
-  follows still gates this and every later connect.
+  Shown ahead of the consent screen until this identity has signed in to a local
+  MCP server on this computer, which is recorded only once one actually
+  succeeds — so a connect that ends up refused leaves the next attempt just as
+  loud. A local connector is trusted by host and not by port, so this is where
+  the user is told what that means; the consent screen that follows still gates
+  this and every later connect.
 -->
 <div class="flex w-full justify-center max-sm:flex-1 sm:max-w-110">
   <AuthPanel>
@@ -37,7 +39,7 @@
       </Badge>
     </div>
     <p class="text-text-tertiary mt-4 text-base text-pretty">
-      {$t`Any program on this computer can ask. We won't ask again here.`}
+      {$t`Any program on this computer can ask.`}
     </p>
 
     <button onclick={onContinue} class="btn btn-primary btn-xl mt-8 w-full">


### PR DESCRIPTION
An MCP server running on the user's own machine can't be connected today. The `/mcp` flow accepts https callbacks only, and its callback allow-list check (`matchDeclaredCallback`) fetches a well-known document from the callback's origin — a request browsers block when that origin is loopback, so every local connect would fail closed even once the scheme gate was relaxed.

## What changes

A local server is trusted as the port-less `http://127.0.0.1`. It binds a fresh port per sign-in and so can't promise one ahead of time, so trust matching for it is by loopback host rather than by exact origin; a remote server still matches by exact origin. Both go through one predicate, `trustsOrigin`, so the connect flow's pre-filter and its authoritative gate on the certified `trusted_url` can't drift apart.

The allow-list is skipped for a local server — decided on the certified `trusted_url`, never on the link, so the branch can't be steered from the fragment. That check defends against a *path* on a shared origin that leaks what's delivered to it: a public host can carry pages many parties wrote, so its origin alone doesn't say who receives the delegation. A local server is one program the user chose to run, and since any port on this computer is already trusted, pinning the path would be defeated by naming a different port.

Only the IPv4 literal counts as loopback. Not `localhost` (a name, subject to whatever resolves it), not `0.0.0.0`, not a name that merely resolves to loopback, and not `::1` — CSP's host-source grammar can't express IPv6 literals, so a `::1` callback would parse here and then die at delivery, the same trap `/cli` documents.

## The canister is untouched

The stored URL stays a stable string, so `hash_trusted_url` and the redemption-time re-check in `mcp_registration.rs` behave exactly as they do for a remote server, and `set_mcp_config`'s revocation compare still fires only on a real change. Removing the connector still deletes the live grant and evicts any in-flight registration.

## UI

Settings picks the connector kind rather than taking a URL for a local one: there's nothing meaningful to type, a text field would have to accept `http://127.0.0.1` and reject `http://127.0.0.1:8000`, and the reachability probe beside it can't run against loopback anyway. A third warning bullet states what trusting loopback means.

Before the first local sign-in for an identity on a given machine, the connect flow says so — decided client-side from the fragment and a device-local record, so it lands *before* the consent screen rather than after the user has already approved. That record is committed only once a connect has actually succeeded, so an attempt that ends at the untrusted screen leaves the next one just as loud.

It's a notice, not a gate. What a local server may do is still decided by the identity's synced config (revocable from any device, taking the live session with it) and by the consent screen on every connect.

## Tests

Coverage for the loopback predicate and the trust comparison, the connect flow with a local trusted server (delivers without a fetch, accepts any port, refuses non-loopback origins and the four lookalikes, and doesn't let a remote entry authorize a loopback callback or vice versa), and that the remote path still enforces the allow-list.

Each new assertion was falsified against three deliberate breakages — removing the port widening, running the allow-list for loopback, and letting a local entry trust any origin — and each was caught.

`npm run check`, `lint:eslint` and `format-check` are clean. `iiConnection.test.ts` and `findWebAuthnFlows.test.ts` fail identically on `main` at this commit and are unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)