### PR TITLE
fix(cli): accept a full app origin in the /cli request

### DIFF
--- a/src/frontend/src/routes/(new-styling)/cli/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/cli/+page.svelte
@@ -59,7 +59,7 @@
     } else {
       cliAuthorizeFunnel.init({
         mode:
-          params.kind === "valid" && params.domain !== undefined
+          params.kind === "valid" && params.appOrigin !== undefined
             ? "app"
             : "generic",
       });
@@ -107,7 +107,7 @@
   // device; otherwise it's a generic CLI sign-in with no gate.
   const isCliAccessGated = (identityNumber: bigint | undefined): boolean =>
     params.kind === "valid" &&
-    params.domain !== undefined &&
+    params.appOrigin !== undefined &&
     identityNumber !== undefined &&
     !cliAccessStore.isEnabled(identityNumber);
 
@@ -203,7 +203,7 @@
       await cliAuthorize({
         authenticated,
         publicKey: params.publicKey,
-        domain: params.domain,
+        appOrigin: params.appOrigin,
         ttlMinutes: params.ttlMinutes,
         callback: params.callback,
         nonce: params.nonce,
@@ -287,7 +287,10 @@
     </AuthPanel>
   </div>
 {:else if phase.kind === "authorize" && params.kind === "valid"}
-  <CliAuthorizeView domain={params.domain} onAuthorize={handleAuthorize} />
+  <CliAuthorizeView
+    appOrigin={params.appOrigin}
+    onAuthorize={handleAuthorize}
+  />
 {:else if phase.kind === "cli-disabled"}
   <CliErrorView />
 {:else if phase.kind === "close"}

--- a/src/frontend/src/routes/(new-styling)/cli/+page.ts
+++ b/src/frontend/src/routes/(new-styling)/cli/+page.ts
@@ -93,10 +93,16 @@ const parseLoopbackCallback = (raw: string | null): string | undefined => {
   return raw;
 };
 
+/**
+ * Whether `hostname` names this machine. IPv4 loopback only: the whole
+ * 127.0.0.0/8, matched as an IP literal rather than by prefix, because
+ * `127.example.com` is a registrable name that resolves anywhere. `::1` is
+ * deliberately absent — the CLI flow is IPv4-only.
+ */
 const isLoopbackHostname = (hostname: string): boolean =>
   hostname === "localhost" ||
-  hostname === "127.0.0.1" ||
-  hostname.endsWith(".localhost");
+  hostname.endsWith(".localhost") ||
+  /^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(hostname);
 
 /**
  * Returns the normalised origin of the app named by `--app`, or undefined if

--- a/src/frontend/src/routes/(new-styling)/cli/+page.ts
+++ b/src/frontend/src/routes/(new-styling)/cli/+page.ts
@@ -93,8 +93,6 @@ const parseLoopbackCallback = (raw: string | null): string | undefined => {
   return raw;
 };
 
-const SCHEME_PREFIX_REGEX = /^[a-z][a-z0-9+.-]*:\/\//i;
-
 const isLoopbackHostname = (hostname: string): boolean =>
   hostname === "localhost" ||
   hostname === "127.0.0.1" ||
@@ -109,9 +107,12 @@ const isLoopbackHostname = (hostname: string): boolean =>
  * userinfo — is rejected rather than silently trimmed.
  */
 const parseAppOrigin = (raw: string): string | undefined => {
+  // Parsing `raw` first and falling back on failure would not work: a bare
+  // `oisy.com:443` parses, taking `oisy.com` for the scheme and `443` for the
+  // path. So a scheme has to be spotted before parsing, not after.
   let url: URL;
   try {
-    url = new URL(SCHEME_PREFIX_REGEX.test(raw) ? raw : `https://${raw}`);
+    url = new URL(raw.includes("://") ? raw : `https://${raw}`);
   } catch {
     return undefined;
   }

--- a/src/frontend/src/routes/(new-styling)/cli/+page.ts
+++ b/src/frontend/src/routes/(new-styling)/cli/+page.ts
@@ -8,7 +8,7 @@ const DEFAULT_TTL_MINUTES = 480;
  * The `/cli` request, parsed from the URL fragment the CLI opens the page with.
  * `valid` carries the validated request — the session public key to delegate
  * to, the loopback callback to post the delegation back to, the single-use
- * nonce, the delegation TTL, and the optional delegation domain. `invalid`
+ * nonce, the delegation TTL, and the optional app origin. `invalid`
  * means the fragment was missing or malformed, and the page shows the
  * invalid-request screen.
  */
@@ -22,9 +22,9 @@ export type CliParams =
        *  this page's POST from a stray or forged local request. */
       nonce: string;
       ttlMinutes: number;
-      /** Delegation domain to get an identity for, or undefined for generic
+      /** Origin of the app to get an identity for, or undefined for generic
        *  mode (the auth page's own default, e.g. cli.id.ai). */
-      domain: string | undefined;
+      appOrigin: string | undefined;
     }
   | { kind: "invalid" };
 
@@ -93,23 +93,44 @@ const parseLoopbackCallback = (raw: string | null): string | undefined => {
   return raw;
 };
 
+const SCHEME_PREFIX_REGEX = /^[a-z][a-z0-9+.-]*:\/\//i;
+
+const isLoopbackHostname = (hostname: string): boolean =>
+  hostname === "localhost" ||
+  hostname === "127.0.0.1" ||
+  hostname.endsWith(".localhost");
+
 /**
- * Returns the normalised hostname if `raw` is a bare hostname (optionally
- * with mixed case), or undefined if it's not. Rejects port, path, query,
- * fragment, scheme prefix, and userinfo by requiring the round-trip
- * through `new URL` to leave only the hostname behind.
+ * Returns the normalised origin of the app named by `--app`, or undefined if
+ * `raw` isn't one. A bare hostname is read as `https://<hostname>`; a scheme
+ * makes `raw` a full origin, so a local app served over http on a non-default
+ * port derives the principal that /authorize derives for the same origin.
+ * Rejects path, query, fragment and userinfo by requiring the round-trip
+ * through `new URL` to leave only the origin behind.
  */
-const parseDomain = (raw: string): string | undefined => {
+const parseAppOrigin = (raw: string): string | undefined => {
+  const withScheme = SCHEME_PREFIX_REGEX.test(raw) ? raw : `https://${raw}`;
   let url: URL;
   try {
-    url = new URL(`https://${raw}`);
+    url = new URL(withScheme);
   } catch {
     return undefined;
   }
-  if (url.hostname.toLowerCase() !== raw.toLowerCase()) {
+  // http would otherwise hand out a principal for an origin any network
+  // attacker can impersonate; loopback is the local-development case, where
+  // there is no CA-trusted cert to serve the app under.
+  const schemeAllowed =
+    url.protocol === "https:" ||
+    (url.protocol === "http:" && isLoopbackHostname(url.hostname));
+  if (!schemeAllowed) {
     return undefined;
   }
-  return url.hostname;
+  if (
+    url.origin.toLowerCase() !== withScheme.replace(/\/$/, "").toLowerCase()
+  ) {
+    return undefined;
+  }
+  return url.origin;
 };
 
 const parseTtl = (raw: string | null): number | undefined => {
@@ -144,10 +165,10 @@ export const load: PageLoad = ({
 
   // `domain` is optional. Absent or empty → generic mode. Present → must parse.
   const domainRaw = params.get("domain");
-  let domain: string | undefined;
+  let appOrigin: string | undefined;
   if (domainRaw !== null && domainRaw !== "") {
-    domain = parseDomain(domainRaw);
-    if (domain === undefined) {
+    appOrigin = parseAppOrigin(domainRaw);
+    if (appOrigin === undefined) {
       return { params: { kind: "invalid" }, status };
     }
   }
@@ -161,7 +182,14 @@ export const load: PageLoad = ({
     return { params: { kind: "invalid" }, status };
   }
   return {
-    params: { kind: "valid", publicKey, callback, nonce, ttlMinutes, domain },
+    params: {
+      kind: "valid",
+      publicKey,
+      callback,
+      nonce,
+      ttlMinutes,
+      appOrigin,
+    },
     status,
   };
 };

--- a/src/frontend/src/routes/(new-styling)/cli/+page.ts
+++ b/src/frontend/src/routes/(new-styling)/cli/+page.ts
@@ -105,14 +105,13 @@ const isLoopbackHostname = (hostname: string): boolean =>
  * `raw` isn't one. A bare hostname is read as `https://<hostname>`; a scheme
  * makes `raw` a full origin, so a local app served over http on a non-default
  * port derives the principal that /authorize derives for the same origin.
- * Rejects path, query, fragment and userinfo by requiring the round-trip
- * through `new URL` to leave only the origin behind.
+ * Anything carrying more than an origin — a path, query, fragment or
+ * userinfo — is rejected rather than silently trimmed.
  */
 const parseAppOrigin = (raw: string): string | undefined => {
-  const withScheme = SCHEME_PREFIX_REGEX.test(raw) ? raw : `https://${raw}`;
   let url: URL;
   try {
-    url = new URL(withScheme);
+    url = new URL(SCHEME_PREFIX_REGEX.test(raw) ? raw : `https://${raw}`);
   } catch {
     return undefined;
   }
@@ -125,8 +124,16 @@ const parseAppOrigin = (raw: string): string | undefined => {
   if (!schemeAllowed) {
     return undefined;
   }
+  // Checked on the parsed URL rather than against the input string: an
+  // explicit default port is a valid part of an origin that `url.origin`
+  // canonicalises away, so comparing the two spellings would reject it.
+  // A bare origin leaves "/" behind as the path.
   if (
-    url.origin.toLowerCase() !== withScheme.replace(/\/$/, "").toLowerCase()
+    url.username !== "" ||
+    url.password !== "" ||
+    url.pathname !== "/" ||
+    url.search !== "" ||
+    url.hash !== ""
   ) {
     return undefined;
   }

--- a/src/frontend/src/routes/(new-styling)/cli/components/CliHeader.svelte
+++ b/src/frontend/src/routes/(new-styling)/cli/components/CliHeader.svelte
@@ -10,14 +10,14 @@
   import { originLabel } from "$lib/utils/urlUtils";
 
   interface Props {
-    /** Hostname of the app the CLI is being authorized for, or undefined for
+    /** Origin of the app the CLI is being authorized for, or undefined for
      *  generic mode (CLI signs into II itself). */
     appOrigin?: string;
   }
 
   const { appOrigin }: Props = $props();
 
-  // The CLI flow has no separate derivation origin: `--app <domain>` is both
+  // The CLI flow has no separate derivation origin: `--app <origin>` is both
   // the origin shown here and the one the linked principal is derived for, so
   // this origin is where the app's metadata is published.
   const emptyMetadataStore = readable<AppMetadata>({});

--- a/src/frontend/src/routes/(new-styling)/cli/load.test.ts
+++ b/src/frontend/src/routes/(new-styling)/cli/load.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+import { load, type CliParams } from "./+page";
+
+// A valid base64url DER session public key, and the loopback callback the CLI
+// listens on. Nothing secret travels in the fragment.
+const PUBLIC_KEY = "cHVibGljLWtleQ";
+const NONCE = "bm9uY2U";
+
+const fragment = (domain?: string): string => {
+  const params = new URLSearchParams();
+  params.set("public_key", PUBLIC_KEY);
+  params.set("callback", "http://127.0.0.1:8000/callback");
+  params.set("nonce", NONCE);
+  if (domain !== undefined) {
+    params.set("domain", domain);
+  }
+  return params.toString();
+};
+
+// `load` is synchronous here; the `PageLoad` signature widens the return to
+// MaybePromise<void | ...>, so narrow it back for the assertions.
+const loadParams = (fragmentString: string): CliParams =>
+  (
+    load({
+      url: new URL(`https://id.ai/cli#${fragmentString}`),
+    } as Parameters<typeof load>[0]) as { params: CliParams }
+  ).params;
+
+const appOriginOf = (domain?: string): string | undefined => {
+  const params = loadParams(fragment(domain));
+  expect(params.kind).toBe("valid");
+  return params.kind === "valid" ? params.appOrigin : undefined;
+};
+
+const expectInvalid = (domain: string): void => {
+  expect(loadParams(fragment(domain)).kind).toBe("invalid");
+};
+
+describe("/cli load: app origin parsing", () => {
+  it("reads a bare hostname as an https origin", () => {
+    expect(appOriginOf("oisy.com")).toBe("https://oisy.com");
+  });
+
+  it("normalises a mixed-case hostname", () => {
+    expect(appOriginOf("OiSy.CoM")).toBe("https://oisy.com");
+  });
+
+  it("keeps an explicit https origin", () => {
+    expect(appOriginOf("https://oisy.com")).toBe("https://oisy.com");
+  });
+
+  it("keeps the port of a bare hostname", () => {
+    expect(appOriginOf("oisy.com:8443")).toBe("https://oisy.com:8443");
+  });
+
+  it("accepts a trailing slash", () => {
+    expect(appOriginOf("https://oisy.com/")).toBe("https://oisy.com");
+  });
+
+  it("is generic mode when the domain is absent", () => {
+    expect(appOriginOf()).toBeUndefined();
+  });
+
+  it("is generic mode when the domain is empty", () => {
+    expect(appOriginOf("")).toBeUndefined();
+  });
+
+  it("rejects a path, query or fragment", () => {
+    expectInvalid("oisy.com/app");
+    expectInvalid("https://oisy.com/app");
+    expectInvalid("https://oisy.com?a=b");
+    expectInvalid("https://oisy.com#a");
+  });
+
+  it("rejects userinfo", () => {
+    expectInvalid("https://user@oisy.com");
+    expectInvalid("user:pass@oisy.com");
+  });
+
+  it("rejects a scheme that is not http(s)", () => {
+    expectInvalid("ftp://oisy.com");
+    expectInvalid("javascript://oisy.com");
+  });
+
+  it("rejects an unparseable domain", () => {
+    expectInvalid("https://");
+    expectInvalid(":8000");
+  });
+});
+
+describe("/cli load: http app origins", () => {
+  it("accepts a local app served over http on a non-default port", () => {
+    expect(appOriginOf("http://frontend.local.localhost:8000")).toBe(
+      "http://frontend.local.localhost:8000",
+    );
+  });
+
+  it("accepts http on localhost and the loopback literal", () => {
+    expect(appOriginOf("http://localhost:5173")).toBe("http://localhost:5173");
+    expect(appOriginOf("http://127.0.0.1:4943")).toBe("http://127.0.0.1:4943");
+  });
+
+  it("rejects http on a host that is not loopback", () => {
+    expectInvalid("http://oisy.com");
+    expectInvalid("http://notlocalhost.com");
+  });
+});

--- a/src/frontend/src/routes/(new-styling)/cli/load.test.ts
+++ b/src/frontend/src/routes/(new-styling)/cli/load.test.ts
@@ -101,9 +101,19 @@ describe("/cli load: http app origins", () => {
     );
   });
 
-  it("accepts http on localhost and the loopback literal", () => {
+  it("accepts http on localhost and anywhere in 127.0.0.0/8", () => {
     expect(appOriginOf("http://localhost:5173")).toBe("http://localhost:5173");
     expect(appOriginOf("http://127.0.0.1:4943")).toBe("http://127.0.0.1:4943");
+    expect(appOriginOf("http://127.0.0.2:8000")).toBe("http://127.0.0.2:8000");
+  });
+
+  it("rejects http on a name that merely starts like loopback", () => {
+    expectInvalid("http://127.example.com");
+    expectInvalid("http://127.0.0.1.example.com");
+  });
+
+  it("rejects http on the IPv6 loopback", () => {
+    expectInvalid("http://[::1]:8000");
   });
 
   it("rejects http on a host that is not loopback", () => {

--- a/src/frontend/src/routes/(new-styling)/cli/load.test.ts
+++ b/src/frontend/src/routes/(new-styling)/cli/load.test.ts
@@ -57,6 +57,12 @@ describe("/cli load: app origin parsing", () => {
     expect(appOriginOf("https://oisy.com/")).toBe("https://oisy.com");
   });
 
+  it("canonicalises an explicit default port away", () => {
+    expect(appOriginOf("https://oisy.com:443")).toBe("https://oisy.com");
+    expect(appOriginOf("oisy.com:443")).toBe("https://oisy.com");
+    expect(appOriginOf("http://localhost:80")).toBe("http://localhost");
+  });
+
   it("is generic mode when the domain is absent", () => {
     expect(appOriginOf()).toBeUndefined();
   });

--- a/src/frontend/src/routes/(new-styling)/cli/utils.test.ts
+++ b/src/frontend/src/routes/(new-styling)/cli/utils.test.ts
@@ -35,6 +35,7 @@ const makeActor = () => {
 const authorize = (
   actor: ReturnType<typeof makeActor>,
   accessLevel: "read-only" | "full-access",
+  appOrigin?: string,
 ) =>
   cliAuthorize({
     authenticated: {
@@ -42,7 +43,7 @@ const authorize = (
       actor: actor as unknown as ActorSubclass<_SERVICE>,
     } as unknown as Authenticated,
     publicKey: toBase64URL(new Uint8Array(32).fill(4)),
-    domain: undefined,
+    appOrigin,
     ttlMinutes: TTL_MINUTES,
     callback: "http://127.0.0.1:8000/callback",
     nonce: "test-nonce",
@@ -88,5 +89,29 @@ describe("cliAuthorize access-level wiring", () => {
     expect(actor.get_account_delegation.mock.calls[0][5]).toEqual([
       { all: null },
     ]);
+  });
+});
+
+describe("cliAuthorize derivation origin", () => {
+  it("derives for the app origin as given", async () => {
+    const actor = makeActor();
+    await authorize(
+      actor,
+      "full-access",
+      "http://frontend.local.localhost:8000",
+    );
+
+    expect(actor.prepare_account_delegation.mock.calls[0][1]).toBe(
+      "http://frontend.local.localhost:8000",
+    );
+  });
+
+  it("remaps a gateway origin to the legacy domain", async () => {
+    const actor = makeActor();
+    await authorize(actor, "full-access", "https://oisy.icp0.io");
+
+    expect(actor.prepare_account_delegation.mock.calls[0][1]).toBe(
+      "https://oisy.ic0.app",
+    );
   });
 });

--- a/src/frontend/src/routes/(new-styling)/cli/utils.ts
+++ b/src/frontend/src/routes/(new-styling)/cli/utils.ts
@@ -17,9 +17,9 @@ interface CliAuthorizeInput {
   authenticated: Authenticated;
   /** base64url-encoded DER session pubkey supplied by the CLI. */
   publicKey: string;
-  /** Delegation domain to get an identity for, or undefined for generic mode
+  /** Origin of the app to get an identity for, or undefined for generic mode
    *  (the auth page's own default, e.g. cli.id.ai). */
-  domain?: string;
+  appOrigin?: string;
   /** Lifetime in minutes. */
   ttlMinutes: number;
   /** Loopback URL the delegation chain is form-POSTed to. */
@@ -32,13 +32,13 @@ interface CliAuthorizeInput {
   accessLevel: AccessLevel;
 }
 
-const derivationOrigin = (domain: string | undefined): string =>
-  // Remap an app domain on a gateway (*.icp0.io / *.icp.net) to *.ic0.app so
+const derivationOrigin = (appOrigin: string | undefined): string =>
+  // Remap an app origin on a gateway (*.icp0.io / *.icp.net) to *.ic0.app so
   // the principal matches the one /authorize derives for the same app. The
   // generic origin is II's own and is never a gateway domain, so it's left be.
-  domain === undefined
+  appOrigin === undefined
     ? CLI_GENERIC_DERIVATION_ORIGIN
-    : remapToLegacyDomain(`https://${domain}`);
+    : remapToLegacyDomain(appOrigin);
 
 /**
  * Builds a two-hop delegation chain rooted at the user's identity and ending
@@ -58,14 +58,14 @@ const derivationOrigin = (domain: string | undefined): string =>
 export const cliAuthorize = async ({
   authenticated,
   publicKey,
-  domain,
+  appOrigin,
   ttlMinutes,
   callback,
   nonce,
   accessLevel,
 }: CliAuthorizeInput): Promise<void> => {
   const { identityNumber, actor } = authenticated;
-  const effectiveOrigin = derivationOrigin(domain);
+  const effectiveOrigin = derivationOrigin(appOrigin);
   const maxTimeToLiveNanos = BigInt(ttlMinutes) * BigInt(60) * BigInt(1e9);
 
   const ephemeralIdentity = await ECDSAKeyIdentity.generate({

--- a/src/frontend/src/routes/(new-styling)/cli/views/CliAuthorizeView.svelte
+++ b/src/frontend/src/routes/(new-styling)/cli/views/CliAuthorizeView.svelte
@@ -10,15 +10,16 @@
   import TerminalBlock from "../components/TerminalBlock.svelte";
   import { Trans } from "$lib/components/locale";
   import { t } from "$lib/stores/locale.store";
+  import { originLabel } from "$lib/utils/urlUtils";
 
   interface Props {
-    /** Hostname of the app the CLI is being authorized for, or undefined for
+    /** Origin of the app the CLI is being authorized for, or undefined for
      *  generic mode. */
-    domain?: string;
+    appOrigin?: string;
     onAuthorize: (accessLevel: AccessLevel) => Promise<void>;
   }
 
-  const { domain, onAuthorize }: Props = $props();
+  const { appOrigin, onAuthorize }: Props = $props();
 
   let busy = $state(false);
   // The access-level selector (shown only when READ_ONLY_MODE is on) starts on
@@ -70,17 +71,19 @@
 
   // Title is short and constant; the app hostname lives in the badge under
   // the connector visual (CliHeader handles it).
-  const isAppMode = $derived(domain !== undefined);
+  const isAppMode = $derived(appOrigin !== undefined);
+  // `originLabel` drops the scheme of a plain https origin, so the echoed
+  // command reads back as the user typed it in both forms of `--app`.
   const command = $derived(
-    isAppMode
-      ? `icp identity link web --app ${domain}`
+    appOrigin !== undefined
+      ? `icp identity link web --app ${originLabel(appOrigin)}`
       : "icp identity link web",
   );
 </script>
 
 <div class="flex w-full justify-center max-sm:flex-1 sm:max-w-110">
   <AuthPanel>
-    <CliHeader appOrigin={isAppMode ? `https://${domain}` : undefined} />
+    <CliHeader {appOrigin} />
 
     <h1 class="text-text-primary mt-2 text-2xl font-medium">
       {isAppMode ? $t`Allow CLI access` : $t`Sign in`}

--- a/src/frontend/tests/e2e-playwright/routes/cli.spec.ts
+++ b/src/frontend/tests/e2e-playwright/routes/cli.spec.ts
@@ -474,3 +474,53 @@ test("`--app` on a gateway domain links the same principal as its *.ic0.app doma
     rootPublicKey(cli.receivedDelegations[0]),
   );
 });
+
+test("`--app` on an http origin links a different principal than its https form", async ({
+  page,
+  cli,
+  isMobile,
+}) => {
+  // One identity, with device CLI access enabled so app mode isn't gated.
+  await addVirtualAuthenticator(page);
+  await page.goto(II_URL);
+  await signUp(page);
+  await page.waitForURL(II_URL + "/manage");
+  await enableCliAccessInSettings(page, isMobile);
+
+  // `--app http://frontend.local.localhost:8000`: a local app on http and a
+  // non-default port, used as the derivation origin as-is. The scheme and port
+  // reach the authorize screen rather than the invalid-request one.
+  await page.goto(
+    await cli.resolveAuthorizeUrl(page, {
+      domain: "http://frontend.local.localhost:8000",
+    }),
+  );
+  await expect(
+    page.getByRole("heading", { name: "Allow CLI access" }),
+  ).toBeVisible();
+  await page.getByRole("button", { name: "Allow access" }).click();
+  await expect(
+    page.getByRole("heading", { name: "You're signed in" }),
+  ).toBeVisible();
+
+  // The same host and port without a scheme, which defaults to https — a
+  // different origin, so a different principal. Navigate off /cli first so the
+  // second visit is a full load (a fragment-only change wouldn't re-run `load`).
+  await page.goto(II_URL);
+  await page.goto(
+    await cli.resolveAuthorizeUrl(page, {
+      domain: "frontend.local.localhost:8000",
+    }),
+  );
+  await page.getByRole("button", { name: "Allow access" }).click();
+  await expect(
+    page.getByRole("heading", { name: "You're signed in" }),
+  ).toBeVisible();
+
+  // http and https on the same host and port are distinct origins ⇒ distinct
+  // root principals. Neither spelling may be normalised into the other.
+  expect(cli.receivedDelegations.length).toBe(2);
+  expect(rootPublicKey(cli.receivedDelegations[1])).not.toBe(
+    rootPublicKey(cli.receivedDelegations[0]),
+  );
+});


### PR DESCRIPTION
## What

`icp identity link web --app <app>` reaches `/cli` as the fragment's `domain`
param. That param only parsed as a bare hostname, and `derivationOrigin`
rebuilt the origin as `https://<hostname>`, so an app served over http or on a
non-default port could not be named:

- `--app frontend.local.localhost:8000` was rejected outright — `parseDomain`
  required the `new URL` round-trip to leave only the hostname, and a port
  fails that — so the page showed **Invalid request**.
- Dropping the port got past the screen but derived a principal for
  `https://frontend.local.localhost`, an origin the app never runs on, so the
  linked identity did not match what the app itself sees.

## Change

`domain` now parses as an origin. A bare hostname still defaults to `https`,
so every released CLI keeps working; a scheme is taken as given. The parsed
value is passed to `prepare_account_delegation` unchanged (still remapped for
the `*.icp0.io` / `*.icp.net` gateways), so `--app http://app.localhost:8000`
derives the same principal `/authorize` derives for that origin.

`http` is confined to loopback hostnames (`localhost`, `*.localhost`,
`127.0.0.1`) — the local-development case, where there is no CA-trusted cert
to serve the app under. Elsewhere it would hand out a principal for an origin
any network attacker can impersonate. Path, query, fragment and userinfo are
still rejected, as before.

The internal `domain` field is renamed to `appOrigin` now that it carries one;
the wire param keeps its name. `CliHeader` already took a full origin, so it
now receives the value directly, and the echoed command runs through
`originLabel` so it reads back as the user typed it in both forms.

## Testing

- New `load.test.ts` covers the parse: bare hostname, mixed case, explicit
  origins, ports, trailing slash, generic mode, and the rejections (path,
  query, userinfo, non-http(s) scheme, http off loopback).
- New cases in `utils.test.ts` assert the origin reaching
  `prepare_account_delegation` — verbatim for a local http origin, remapped
  for a gateway origin.
- Both sets were confirmed to fail against the previous behaviour.
- `tsc`, `svelte-check` (0 errors) and `eslint` clean.

## Note

Whether `icp` forwards `--app` verbatim into the fragment or validates it as a
hostname first is untested here — if it validates, a matching change is needed
in the CLI repo before the http form can be passed end to end.