### PR TITLE
fix(be): legacy register checks the pubkey it binds

### DIFF
--- a/src/internet_identity/src/anchor_management/registration.rs
+++ b/src/internet_identity/src/anchor_management/registration.rs
@@ -1,4 +1,6 @@
-use crate::anchor_management::{activity_bookkeeping, post_operation_bookkeeping};
+use crate::anchor_management::{
+    activity_bookkeeping, check_pubkey_is_not_used, post_operation_bookkeeping,
+};
 use crate::state;
 use crate::state::ChallengeInfo;
 use crate::storage::anchor::Device;
@@ -85,6 +87,16 @@ pub fn register(
 
     // sanity check
     verify_caller_is_device_or_temp_key(&temp_key, &device_principal);
+
+    check_pubkey_is_not_used(&device.pubkey).unwrap_or_else(|err| trap(&err));
+
+    // A device without a credential id signs for itself, so no temp key stands in for it.
+    if device.credential_id.is_none() && caller() != device_principal {
+        trap(&format!(
+            "caller {caller} could not be authenticated against device pubkey {device_principal}",
+            caller = caller()
+        ));
+    }
 
     let now = time();
     let allocation = state::storage_borrow_mut(|storage| storage.allocate_anchor(now));

--- a/src/internet_identity/tests/integration/anchor_management/registration/temp_keys.rs
+++ b/src/internet_identity/tests/integration/anchor_management/registration/temp_keys.rs
@@ -201,6 +201,58 @@ fn should_provide_temp_keys_metric() -> Result<(), RejectResponse> {
     Ok(())
 }
 
+#[test]
+fn should_not_register_a_credential_less_device_with_a_temp_key() {
+    let env = env();
+    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let temp_key = test_principal(0);
+    let credential_less_device = DeviceData {
+        credential_id: None,
+        ..device(7)
+    };
+    assert_ne!(temp_key, credential_less_device.principal());
+
+    let challenge = api::create_challenge(&env, canister_id).unwrap();
+    let result = api::register(
+        &env,
+        canister_id,
+        temp_key,
+        &credential_less_device,
+        &challenge_solution(challenge),
+        Some(temp_key),
+    );
+
+    expect_user_error_with_message(
+        result,
+        ErrorCode::CanisterCalledTrap,
+        Regex::new("could not be authenticated against device pubkey").unwrap(),
+    );
+}
+
+#[test]
+fn should_not_register_a_pubkey_another_anchor_already_uses() {
+    let env = env();
+    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let existing = device(3);
+    flows::register_anchor_with_device(&env, canister_id, &existing);
+
+    let challenge = api::create_challenge(&env, canister_id).unwrap();
+    let result = api::register(
+        &env,
+        canister_id,
+        existing.principal(),
+        &existing,
+        &challenge_solution(challenge),
+        None,
+    );
+
+    expect_user_error_with_message(
+        result,
+        ErrorCode::CanisterCalledTrap,
+        Regex::new("a device with this public key is already used").unwrap(),
+    );
+}
+
 fn register_with_temp_key(
     env: &PocketIc,
     canister_id: CanisterId,


### PR DESCRIPTION
The legacy `register` ran no uniqueness check on the device pubkey it binds, and its caller check
accepts an arbitrary temp key in place of the device principal, so the pubkey it binds need not be
one the caller holds.

## Changes

`register` now calls `check_pubkey_is_not_used`, the same guard `add`, `update` and `replace`
already run, and traps on a conflict as those do. `verify_caller_is_device_or_temp_key` still
accepts a temp key, which is unavoidable for a WebAuthn credential because it cannot sign canister
calls, but a device with no credential id signs for itself, so `register` now requires the caller
to be that device's principal.

The frontend does not call `register`; it is reachable only over Candid.

## Tests

Registering a pubkey another anchor already uses fails, and a device without a credential id
cannot be registered behind a temp key. Unit tests, clippy and the integration build are green
locally.
