### PR TITLE
feat(be): sweep recovery keys that predate the recovery-phrase index

### DIFF
--- a/src/canister_tests/src/api/internet_identity.rs
+++ b/src/canister_tests/src/api/internet_identity.rs
@@ -142,6 +142,22 @@ pub fn lookup(
     query_candid(env, canister_id, "lookup", (anchor_number,)).map(|(x,)| x)
 }
 
+pub fn lookup_caller_identity_by_recovery_phrase(
+    env: &PocketIc,
+    canister_id: CanisterId,
+    sender: Principal,
+) -> Result<Option<types::IdentityNumber>, RejectResponse> {
+    call_candid_as(
+        env,
+        canister_id,
+        RawEffectivePrincipal::None,
+        sender,
+        "lookup_caller_identity_by_recovery_phrase",
+        (),
+    )
+    .map(|(x,)| x)
+}
+
 pub fn get_anchor_credentials(
     env: &PocketIc,
     canister_id: CanisterId,

--- a/src/canister_tests/src/api/internet_identity/api_v2.rs
+++ b/src/canister_tests/src/api/internet_identity/api_v2.rs
@@ -747,6 +747,22 @@ pub fn get_account_delegation_with_read_only(
     .map(|(x,)| x)
 }
 
+/// Hidden monitoring endpoint: `(indexed_entries, collisions, is_done)` for the
+/// recovery-phrase principal index sweep.
+pub fn recovery_phrase_index_sweep_status(
+    env: &PocketIc,
+    canister_id: CanisterId,
+    sender: Principal,
+) -> Result<(u64, u64, bool), RejectResponse> {
+    query_candid_as(
+        env,
+        canister_id,
+        sender,
+        "recovery_phrase_index_sweep_status",
+        (),
+    )
+}
+
 /// Hidden monitoring endpoint: `(indexed_entries, skipped_rows, is_done)` for the
 /// account principal index backfill.
 pub fn account_principal_index_backfill_status(

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -854,6 +854,12 @@ fn initialize(maybe_arg: Option<InternetIdentityInit>) {
     // purpose: nothing depends on it, and the write path keeps the index in step by
     // itself.
     init_account_principal_index_backfill_timer();
+
+    // TEMPORARY: a one-time sweep, to index the recovery keys that predate the
+    // recovery-phrase principal index. Remove once every deployment has upgraded through a
+    // build that carries it and the sweep reports done — its progress is stable state, so
+    // an upgrade resumes it rather than starting over.
+    init_recovery_phrase_index_sweep_timer();
 }
 
 const ACCOUNT_PRINCIPAL_INDEX_BACKFILL_BACKOFF: Duration = Duration::from_secs(1);
@@ -941,6 +947,88 @@ fn init_account_principal_index_backfill_timer() {
         run_account_principal_index_backfill_batch,
     );
     ACCOUNT_PRINCIPAL_INDEX_BACKFILL_TIMER_ID.with_borrow_mut(|id_slot| {
+        if let Some(old_id) = id_slot.replace(timer_id) {
+            ic_cdk_timers::clear_timer(old_id);
+        }
+    });
+}
+
+const RECOVERY_PHRASE_INDEX_SWEEP_BACKOFF: Duration = Duration::from_secs(1);
+
+const RECOVERY_PHRASE_INDEX_SWEEP_BATCH_SIZE: u64 = 500;
+
+thread_local! {
+    static RECOVERY_PHRASE_INDEX_SWEEP_TIMER_ID: RefCell<Option<TimerId>> = const { RefCell::new(None) };
+}
+
+/// Returns `(indexed_entries, collisions, is_done)` so monitoring can track the sweep.
+///
+/// A non-zero collision count is what the sweep is worth reading for: those are recovery
+/// principals the index already maps to a different anchor than the one holding the key,
+/// which is either a duplicated phrase or a claim by an anchor that does not own it.
+#[query(hidden = true)]
+fn recovery_phrase_index_sweep_status() -> (u64, u64, bool) {
+    let sweep = state::persistent_state(|persistent_state| {
+        persistent_state
+            .recovery_phrase_index_sweep
+            .unwrap_or_default()
+    });
+    (sweep.indexed, sweep.collisions, sweep.is_done)
+}
+
+fn run_recovery_phrase_index_sweep_batch() {
+    let sweep = state::persistent_state(|persistent_state| {
+        persistent_state
+            .recovery_phrase_index_sweep
+            .unwrap_or_default()
+    });
+    if sweep.is_done {
+        // A timer fired after the sweep finished, so the clear below did not take. Repeated
+        // rather than assumed, or it fires every second for the life of the canister.
+        clear_recovery_phrase_index_sweep_timer();
+        return;
+    }
+
+    let swept = state::storage_borrow_mut(|storage| {
+        storage.sweep_recovery_phrase_principal_index_batch(
+            sweep,
+            RECOVERY_PHRASE_INDEX_SWEEP_BATCH_SIZE,
+        )
+    });
+    state::persistent_state_mut(|persistent_state| {
+        persistent_state.recovery_phrase_index_sweep = Some(swept);
+    });
+
+    if swept.is_done {
+        clear_recovery_phrase_index_sweep_timer();
+        ic_cdk::println!(
+            "Recovery phrase principal index sweep COMPLETED ({indexed} entries, {collisions} collisions).",
+            indexed = swept.indexed,
+            collisions = swept.collisions,
+        );
+    }
+}
+
+/// Stops the sweep's timer and forgets its id. Does nothing where there is no id, so it is
+/// safe to call from either the completion it belongs to or a firing that should not have
+/// happened.
+fn clear_recovery_phrase_index_sweep_timer() {
+    RECOVERY_PHRASE_INDEX_SWEEP_TIMER_ID.with_borrow_mut(|id_slot| {
+        if let Some(timer_id) = id_slot.take() {
+            ic_cdk_timers::clear_timer(timer_id);
+        }
+    });
+}
+
+/// Safe to call from both `init` and `post_upgrade`: with nothing to index the first batch
+/// immediately reports completion, and a sweep already finished before this upgrade stops
+/// on its first firing.
+fn init_recovery_phrase_index_sweep_timer() {
+    let timer_id = ic_cdk_timers::set_timer_interval(
+        RECOVERY_PHRASE_INDEX_SWEEP_BACKOFF,
+        run_recovery_phrase_index_sweep_batch,
+    );
+    RECOVERY_PHRASE_INDEX_SWEEP_TIMER_ID.with_borrow_mut(|id_slot| {
         if let Some(old_id) = id_slot.replace(timer_id) {
             ic_cdk_timers::clear_timer(old_id);
         }

--- a/src/internet_identity/src/state.rs
+++ b/src/internet_identity/src/state.rs
@@ -8,7 +8,7 @@ use crate::stats::activity_stats::activity_counter::domain_active_anchor_counter
 use crate::stats::activity_stats::ActivityStats;
 use crate::stats::event_stats::EventKey;
 use crate::storage::anchor::Anchor;
-use crate::storage::MAX_ENTRIES;
+use crate::storage::{RecoveryPhraseIndexSweep, MAX_ENTRIES};
 use crate::{random_salt, Storage};
 use asset_util::CertifiedAssets;
 use candid::{CandidType, Deserialize, Principal};
@@ -109,6 +109,7 @@ pub struct PersistentState {
     pub active_authn_method_stats: ActivityStats<AuthnMethodCounter>,
     // Configuration of the captcha challenge during registration flow
     pub captcha_config: CaptchaConfig,
+    pub recovery_phrase_index_sweep: Option<RecoveryPhraseIndexSweep>,
     // Configuration for Related Origins Requests
     pub related_origins: Option<Vec<String>>,
     // Origin of the II backend canister (e.g. "https://backend.id.ai", no
@@ -165,6 +166,7 @@ impl Default for PersistentState {
             domain_active_anchor_stats: ActivityStats::new(time),
             active_authn_method_stats: ActivityStats::new(time),
             captcha_config: DEFAULT_CAPTCHA_CONFIG,
+            recovery_phrase_index_sweep: None,
             related_origins: None,
             backend_origin: None,
             new_flow_origins: None,

--- a/src/internet_identity/src/storage.rs
+++ b/src/internet_identity/src/storage.rs
@@ -3218,6 +3218,103 @@ impl<M: Memory + Clone> Storage<M> {
             ),
         ])
     }
+
+    /// Indexes one batch of the recovery keys that predate the recovery-phrase principal
+    /// index. An entry is written only where the principal is unclaimed, so a batch that
+    /// runs twice writes the same values and a claim is never taken from its owner.
+    ///
+    /// `batch_size` bounds anchors, which bounds work: the devices per anchor are capped,
+    /// so the recovery keys behind one anchor cost a bounded number of principal
+    /// derivations and stable writes.
+    pub fn sweep_recovery_phrase_principal_index_batch(
+        &mut self,
+        sweep: RecoveryPhraseIndexSweep,
+        batch_size: u64,
+    ) -> RecoveryPhraseIndexSweep {
+        let mut sweep = sweep;
+
+        // Examining nothing is not finishing. Reporting completion here would stop a sweep
+        // that has not read a single anchor, and a lookup miss would then be taken as proof
+        // no anchor holds that recovery principal.
+        if sweep.is_done || batch_size == 0 {
+            return sweep;
+        }
+
+        use std::ops::Bound as RangeBound;
+        let range = match sweep.resume_from {
+            Some(anchor_number) => (RangeBound::Included(anchor_number), RangeBound::Unbounded),
+            None => (RangeBound::Unbounded, RangeBound::Unbounded),
+        };
+
+        // Collected so the read borrow ends before the writes below, and capped so the
+        // anchors behind this batch are never materialised.
+        let wanted = usize::try_from(batch_size).unwrap_or(usize::MAX);
+        let batch: Vec<(AnchorNumber, Vec<StorableRecoveryKey>)> = self
+            .stable_anchor_memory
+            .range(range)
+            .take(wanted)
+            .map(|(anchor_number, anchor)| {
+                (anchor_number, anchor.recovery_keys.unwrap_or_default())
+            })
+            .collect();
+
+        let Some((last_anchor_number, _)) = batch.last() else {
+            sweep.is_done = true;
+            sweep.resume_from = None;
+            return sweep;
+        };
+        let resume_from = last_anchor_number.saturating_add(1);
+        let read_to_the_end = batch.len() < wanted;
+
+        for (anchor_number, recovery_keys) in batch {
+            for recovery_key in recovery_keys {
+                let principal = Principal::self_authenticating(&recovery_key.pubkey);
+                match self
+                    .lookup_anchor_with_recovery_phrase_principal_memory
+                    .get(&principal)
+                {
+                    Some(indexed_anchor_number) if indexed_anchor_number != anchor_number => {
+                        sweep.collisions = sweep.collisions.saturating_add(1);
+                        ic_cdk::println!(
+                            "WARNING: recovery principal {:?} held by anchor {} is indexed for \
+                             anchor {}; leaving the index unchanged",
+                            principal,
+                            anchor_number,
+                            indexed_anchor_number,
+                        );
+                    }
+                    Some(_) => {}
+                    None => {
+                        self.lookup_anchor_with_recovery_phrase_principal_memory
+                            .insert(principal, anchor_number);
+                        sweep.indexed = sweep.indexed.saturating_add(1);
+                    }
+                }
+            }
+        }
+
+        sweep.is_done = read_to_the_end;
+        sweep.resume_from = (!read_to_the_end).then_some(resume_from);
+        sweep
+    }
+}
+
+/// How far the recovery-phrase principal index sweep has got, and what it found.
+///
+/// Persisted in [`crate::state::PersistentState`] rather than the heap, so an upgrade
+/// resumes the sweep instead of restarting it. The counters are the point of the sweep as
+/// much as the writes are: `indexed` is how many recovery principals predated the index,
+/// and `collisions` is how many were already claimed by a different anchor.
+#[derive(Clone, Copy, CandidType, Deserialize, Debug, Default, Eq, PartialEq)]
+pub struct RecoveryPhraseIndexSweep {
+    /// The next anchor to examine. `None` before the first batch and once finished.
+    pub resume_from: Option<AnchorNumber>,
+    pub is_done: bool,
+    pub indexed: u64,
+    /// Recovery principals the index already maps to a different anchor. The sweep cannot
+    /// tell a duplicated phrase from a claim made by an anchor that does not own it, so it
+    /// reports them and changes nothing.
+    pub collisions: u64,
 }
 
 /// How far the sweep has got: which list, and how many of that list's references are

--- a/src/internet_identity/src/storage/storable/storable_persistent_state.rs
+++ b/src/internet_identity/src/storage/storable/storable_persistent_state.rs
@@ -5,6 +5,7 @@ use crate::stats::activity_stats::activity_counter::authn_method_counter::AuthnM
 use crate::stats::activity_stats::activity_counter::domain_active_anchor_counter::DomainActiveAnchorCounter;
 use crate::stats::activity_stats::ActivityStats;
 use crate::stats::event_stats::EventKey;
+use crate::storage::RecoveryPhraseIndexSweep;
 use candid::{CandidType, Deserialize};
 use ic_stable_structures::storable::Bound;
 use ic_stable_structures::Storable;
@@ -47,6 +48,7 @@ pub struct StorablePersistentState {
     dnssec_config: Option<DnssecConfig>,
     doh_config: Option<DohConfig>,
     mcp_official_url: Option<String>,
+    recovery_phrase_index_sweep: Option<RecoveryPhraseIndexSweep>,
 }
 
 impl Storable for StorablePersistentState {
@@ -98,6 +100,7 @@ impl From<PersistentState> for StorablePersistentState {
             dnssec_config: s.dnssec_config,
             doh_config: s.doh_config,
             mcp_official_url: s.mcp_official_url,
+            recovery_phrase_index_sweep: s.recovery_phrase_index_sweep,
         }
     }
 }
@@ -127,6 +130,7 @@ impl From<StorablePersistentState> for PersistentState {
             dnssec_config: s.dnssec_config,
             doh_config: s.doh_config,
             mcp_official_url: s.mcp_official_url,
+            recovery_phrase_index_sweep: s.recovery_phrase_index_sweep,
         }
     }
 }
@@ -184,6 +188,7 @@ mod tests {
             dnssec_config: None,
             doh_config: None,
             mcp_official_url: None,
+            recovery_phrase_index_sweep: None,
         };
 
         pretty_assertions::assert_eq!(StorablePersistentState::default(), expected_defaults);
@@ -217,6 +222,7 @@ mod tests {
             dnssec_config: None,
             doh_config: None,
             mcp_official_url: None,
+            recovery_phrase_index_sweep: None,
         };
         pretty_assertions::assert_eq!(PersistentState::default(), expected_defaults);
     }

--- a/src/internet_identity/src/storage/tests.rs
+++ b/src/internet_identity/src/storage/tests.rs
@@ -5196,3 +5196,151 @@ mod account_principal_index_backfill_tests {
         );
     }
 }
+
+mod recovery_phrase_index_sweep_tests {
+    use super::*;
+    use crate::storage::anchor::Device;
+    use crate::storage::RecoveryPhraseIndexSweep;
+    use candid::Principal;
+    use ic_stable_structures::VectorMemory;
+    use internet_identity_interface::internet_identity::types::{AnchorNumber, KeyType, PublicKey};
+    use pretty_assertions::assert_eq;
+
+    fn pubkey(n: u8) -> PublicKey {
+        vec![n; 32].into()
+    }
+
+    fn seed_phrase_device(pubkey: PublicKey) -> Device {
+        Device {
+            pubkey,
+            alias: "seed".to_string(),
+            credential_id: None,
+            aaguid: None,
+            purpose: Purpose::Recovery,
+            key_type: KeyType::SeedPhrase,
+            protection: DeviceProtection::Unprotected,
+            origin: None,
+            metadata: None,
+            last_usage_timestamp: None,
+        }
+    }
+
+    /// Anchors holding a recovery key with no index entry, which is the state of every
+    /// anchor not written since the index was introduced.
+    fn storage_with_unindexed_anchors(count: u8) -> (Storage<VectorMemory>, Vec<AnchorNumber>) {
+        let mut storage = Storage::new((10_000, 3_784_873), VectorMemory::default());
+        let mut anchor_numbers = vec![];
+        for index in 0..count {
+            let mut anchor = storage.allocate_anchor(0).unwrap();
+            anchor
+                .add_device(seed_phrase_device(pubkey(index)))
+                .unwrap();
+            anchor_numbers.push(anchor.anchor_number());
+            storage.write(anchor).unwrap();
+            storage
+                .lookup_anchor_with_recovery_phrase_principal_memory
+                .remove(&Principal::self_authenticating(pubkey(index)));
+        }
+        (storage, anchor_numbers)
+    }
+
+    #[test]
+    fn indexes_recovery_keys_that_predate_the_index() {
+        let (mut storage, anchor_numbers) = storage_with_unindexed_anchors(3);
+
+        let sweep = storage.sweep_recovery_phrase_principal_index_batch(Default::default(), 100);
+
+        assert_eq!(sweep.indexed, 3);
+        assert_eq!(sweep.collisions, 0);
+        assert!(sweep.is_done);
+        for (index, anchor_number) in anchor_numbers.into_iter().enumerate() {
+            assert_eq!(
+                storage.lookup_anchor_with_pubkey(&pubkey(index as u8)),
+                Some(anchor_number)
+            );
+        }
+    }
+
+    #[test]
+    fn resumes_where_the_previous_batch_stopped() {
+        let (mut storage, anchor_numbers) = storage_with_unindexed_anchors(3);
+
+        let first = storage.sweep_recovery_phrase_principal_index_batch(Default::default(), 2);
+        assert_eq!(first.indexed, 2);
+        assert!(!first.is_done);
+        assert_eq!(first.resume_from, Some(anchor_numbers[1] + 1));
+
+        let second = storage.sweep_recovery_phrase_principal_index_batch(first, 2);
+        assert_eq!(second.indexed, 3);
+        assert!(second.is_done);
+        assert_eq!(second.resume_from, None);
+    }
+
+    #[test]
+    fn leaves_a_principal_claimed_by_another_anchor_alone() {
+        let (mut storage, anchor_numbers) = storage_with_unindexed_anchors(1);
+        let squatter = anchor_numbers[0] + 7;
+        storage
+            .lookup_anchor_with_recovery_phrase_principal_memory
+            .insert(Principal::self_authenticating(pubkey(0)), squatter);
+
+        let sweep = storage.sweep_recovery_phrase_principal_index_batch(Default::default(), 100);
+
+        assert_eq!(sweep.indexed, 0);
+        assert_eq!(sweep.collisions, 1);
+        assert!(sweep.is_done);
+        assert_eq!(
+            storage.lookup_anchor_with_pubkey(&pubkey(0)),
+            Some(squatter)
+        );
+    }
+
+    #[test]
+    fn running_again_writes_the_same_entries() {
+        let (mut storage, _) = storage_with_unindexed_anchors(3);
+
+        let first = storage.sweep_recovery_phrase_principal_index_batch(Default::default(), 100);
+        let second = storage
+            .sweep_recovery_phrase_principal_index_batch(RecoveryPhraseIndexSweep::default(), 100);
+
+        assert_eq!(first.indexed, 3);
+        assert_eq!(second.indexed, 0);
+        assert_eq!(second.collisions, 0);
+        assert!(second.is_done);
+    }
+
+    #[test]
+    fn a_batch_that_examines_nothing_is_not_done() {
+        let (mut storage, _) = storage_with_unindexed_anchors(3);
+
+        let sweep = storage.sweep_recovery_phrase_principal_index_batch(Default::default(), 0);
+
+        assert_eq!(sweep.indexed, 0);
+        assert!(!sweep.is_done);
+        assert_eq!(sweep.resume_from, None);
+    }
+
+    #[test]
+    fn a_canister_with_no_anchors_finishes_immediately() {
+        let mut storage = Storage::new((10_000, 3_784_873), VectorMemory::default());
+
+        let sweep = storage.sweep_recovery_phrase_principal_index_batch(Default::default(), 100);
+
+        assert_eq!(sweep.indexed, 0);
+        assert!(sweep.is_done);
+    }
+
+    #[test]
+    fn a_finished_sweep_does_no_further_work() {
+        let (mut storage, _) = storage_with_unindexed_anchors(3);
+        let done = RecoveryPhraseIndexSweep {
+            is_done: true,
+            ..Default::default()
+        };
+
+        let sweep = storage.sweep_recovery_phrase_principal_index_batch(done, 100);
+
+        assert_eq!(sweep.indexed, 0);
+        assert_eq!(storage.lookup_anchor_with_pubkey(&pubkey(0)), None);
+    }
+}

--- a/src/internet_identity/tests/integration/upgrade.rs
+++ b/src/internet_identity/tests/integration/upgrade.rs
@@ -8,6 +8,49 @@ use internet_identity_interface::internet_identity::types::*;
 use pocket_ic::ErrorCode::CanisterCalledTrap;
 use pocket_ic::RejectResponse;
 use regex::Regex;
+use std::time::Duration;
+
+/// The recovery-phrase principal index sweep runs after an upgrade and reports completion,
+/// rather than ticking its timer for the life of the canister.
+///
+/// The entry count is deliberately not asserted. The previous release already maintains the
+/// index as it writes, so an anchor registered against it is indexed before the sweep ever
+/// sees it, and a sweep that finds every entry already correct reports nothing indexed.
+#[test]
+fn recovery_phrase_index_sweep_completes_after_an_upgrade() -> Result<(), RejectResponse> {
+    let env = env();
+    let canister_id = install_ii_canister(&env, II_WASM_PREVIOUS.clone());
+    let identity_number = flows::register_anchor(&env, canister_id);
+    api::add(
+        &env,
+        canister_id,
+        principal_1(),
+        identity_number,
+        &recovery_device_data_1(),
+    )?;
+
+    upgrade_ii_canister(&env, canister_id, II_WASM.clone());
+
+    env.advance_time(Duration::from_secs(5));
+    for _ in 0..5 {
+        env.tick();
+    }
+
+    let (_, collisions, is_done) =
+        canister_tests::api::internet_identity::api_v2::recovery_phrase_index_sweep_status(
+            &env,
+            canister_id,
+            principal_1(),
+        )?;
+    assert!(is_done, "the sweep should report completion");
+    assert_eq!(collisions, 0);
+
+    assert_eq!(
+        api::lookup_caller_identity_by_recovery_phrase(&env, canister_id, principal_recovery_1(),)?,
+        Some(identity_number)
+    );
+    Ok(())
+}
 
 /// Basic upgrade test.
 #[test]


### PR DESCRIPTION
The recovery-phrase principal index went in behind the write path (#3487), so it holds entries
only for anchors written since. The passkey pubkey index had the same shape, was swept once
(#3659) and the sweep retired (#3713); this one never was. So the uniqueness guard that reads it
cannot see a recovery key held by an anchor untouched since the index landed.

## Changes

`initialize` starts a timer, from both `init` and `post_upgrade`, that drives
`Storage::sweep_recovery_phrase_principal_index_batch`. Each batch walks anchors and indexes
every recovery principal whose slot is free, which is
`sync_anchor_with_recovery_phrase_principal_index` against an empty previous state — the shape
`force_sync_all_indices` used for the passkey index. A slot held by a different anchor is counted
and logged rather than overwritten, because the sweep cannot tell a duplicated phrase from a claim
by an anchor that does not own the key, so it reports and changes nothing.

Progress and counters live in `PersistentState` rather than the heap. #4312 is currently retiring
the account principal index sweep partly because its completion flag was heap state, so every
upgrade forgot it and walked every list again; this one resumes instead.
`recovery_phrase_index_sweep_status` reports entries indexed, collisions and completion. It is
hidden, so the Candid interface does not change.

The counters are worth as much as the writes: `indexed` is how many recovery principals predated
the index, and `collisions` is how many were already claimed by another anchor. Neither number is
observable any other way.

Like its predecessors this is temporary and wants retiring in a follow-up once every deployment
has upgraded through it and it reports done.

## Tests

Unit tests cover indexing unindexed anchors, resuming across batches, leaving a claim by another
anchor alone, idempotence, and the empty and finished cases. An upgrade test asserts the sweep
reports completion rather than ticking for the life of the canister; it deliberately does not
assert an entry count, since the previous release already indexes as it writes and a sweep that
finds everything correct reports nothing indexed. That assertion is what #4312 had to remove.

774 unit tests, clippy and the integration build are green locally.
